### PR TITLE
Timeout for GATTServer connect() disconnect() function

### DIFF
--- a/components/net/bluetooth_thread.rs
+++ b/components/net/bluetooth_thread.rs
@@ -35,7 +35,7 @@ const VALUE_ERROR: &'static str = "No characteristic or descriptor found with th
 const SECURITY_ERROR: &'static str = "The operation is insecure";
 const NETWORK_ERROR: &'static str = "A network error occurred";
 // A transaction not completed within 30 seconds shall time out. Such a transaction shall be considered to have failed.
-// https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=286439 ([Vol 3, Part F] page 480)
+// https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=286439 (Vol. 3, page 480)
 const MAXIMUM_TARNSACTION_TIME: u32 = 30;
 const CONNECTION_TIMEOUT_MS: u64 = 1000;
 // The discovery session needs some time to find any nearby devices

--- a/components/net/bluetooth_thread.rs
+++ b/components/net/bluetooth_thread.rs
@@ -35,7 +35,7 @@ const VALUE_ERROR: &'static str = "No characteristic or descriptor found with th
 const SECURITY_ERROR: &'static str = "The operation is insecure";
 const NETWORK_ERROR: &'static str = "A network error occurred";
 // A transaction not completed within 30 seconds shall time out. Such a transaction shall be considered to have failed.
-// https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=286439 (p. 480)
+// https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=286439 ([Vol 3, Part F] page 480)
 const MAXIMUM_TARNSACTION_TIME: u32 = 30;
 const CONNECTION_TIMEOUT_MS: u64 = 1000;
 // The discovery session needs some time to find any nearby devices
@@ -483,7 +483,7 @@ impl BluetoothManager {
                     return drop(sender.send(Ok(true)));
                 }
                 let _ = d.connect();
-                for _ in 0..MAXIMUM_TARNSACTION_TIME {
+                while (0..MAXIMUM_TARNSACTION_TIME).next().is_some() {
                     match d.is_connected().unwrap_or(false) {
                         true => return drop(sender.send(Ok(true))),
                         false => thread::sleep(Duration::from_millis(CONNECTION_TIMEOUT_MS)),
@@ -504,10 +504,10 @@ impl BluetoothManager {
                     return drop(sender.send(Ok(false)));
                 }
                 let _ = d.disconnect();
-                for _ in 0..MAXIMUM_TARNSACTION_TIME {
+                while (0..MAXIMUM_TARNSACTION_TIME).next().is_some() {
                     match d.is_connected().unwrap_or(true) {
-                        false => return drop(sender.send(Ok(false))),
                         true => thread::sleep(Duration::from_millis(CONNECTION_TIMEOUT_MS)),
+                        false => return drop(sender.send(Ok(false))),
                     }
                 }
                 return drop(sender.send(Err(String::from(NETWORK_ERROR))));

--- a/components/net/bluetooth_thread.rs
+++ b/components/net/bluetooth_thread.rs
@@ -37,6 +37,7 @@ const NETWORK_ERROR: &'static str = "A network error occurred";
 // A transaction not completed within 30 seconds shall time out. Such a transaction shall be considered to have failed.
 // https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=286439 (p. 480)
 const MAXIMUM_TARNSACTION_TIME: u32 = 30;
+const CONNECTION_TIMEOUT_MS: u64 = 1000;
 // The discovery session needs some time to find any nearby devices
 const DISCOVERY_TIMEOUT_MS: u64 = 1500;
 #[cfg(target_os = "linux")]
@@ -481,16 +482,20 @@ impl BluetoothManager {
                 match d.is_connected().unwrap_or(false) {
                     true => true,
                     false => {
-                        let _ = d.connect();
-                        for _ in 0..MAXIMUM_TARNSACTION_TIME {
-                            match d.is_connected().unwrap_or(false) {
-                                true => break,
-                                false => thread::sleep(Duration::from_millis(1000)),
-                            }
-                        }
-                        match d.is_connected().unwrap_or(false) {
-                            true => true,
-                            false => return drop(sender.send(Err(String::from(NETWORK_ERROR)))),
+                        match d.connect() {
+                            Ok(_) => true,
+                            Err(_) => {
+                                for _ in 0..MAXIMUM_TARNSACTION_TIME {
+                                    match d.is_connected().unwrap_or(false) {
+                                        true => break,
+                                        false => thread::sleep(Duration::from_millis(CONNECTION_TIMEOUT_MS)),
+                                    }
+                                }
+                                match d.is_connected().unwrap_or(false) {
+                                    true => true,
+                                    false => return drop(sender.send(Err(String::from(NETWORK_ERROR)))),
+                                }
+                            },
                         }
                     },
                 }
@@ -506,10 +511,25 @@ impl BluetoothManager {
 
         let connected = match self.get_device(&mut adapter, &device_id) {
             Some(d) => {
-                if d.is_connected().unwrap_or(false) {
-                    d.disconnect().is_ok()
-                } else {
-                    false
+                match d.is_connected().unwrap_or(true) {
+                    false => false,
+                    true => {
+                        match d.disconnect() {
+                            Ok(_) => false,
+                            Err(_) => {
+                                for i in 0..MAXIMUM_TARNSACTION_TIME {
+                                    match d.is_connected().unwrap_or(true) {
+                                        false => break,
+                                        true => thread::sleep(Duration::from_millis(CONNECTION_TIMEOUT_MS)),
+                                    }
+                                }
+                                match d.is_connected().unwrap_or(true) {
+                                    false => false,
+                                    true => return drop(sender.send(Err(String::from(NETWORK_ERROR)))),
+                                }
+                            },
+                        }
+                    },
                 }
             },
             None => return drop(sender.send(Err(String::from(DEVICE_ERROR)))),

--- a/components/net/bluetooth_thread.rs
+++ b/components/net/bluetooth_thread.rs
@@ -483,7 +483,7 @@ impl BluetoothManager {
                     return drop(sender.send(Ok(true)));
                 }
                 let _ = d.connect();
-                while (0..MAXIMUM_TARNSACTION_TIME).next().is_some() {
+                for _ in 0..MAXIMUM_TARNSACTION_TIME {
                     match d.is_connected().unwrap_or(false) {
                         true => return drop(sender.send(Ok(true))),
                         false => thread::sleep(Duration::from_millis(CONNECTION_TIMEOUT_MS)),
@@ -504,7 +504,7 @@ impl BluetoothManager {
                     return drop(sender.send(Ok(false)));
                 }
                 let _ = d.disconnect();
-                while (0..MAXIMUM_TARNSACTION_TIME).next().is_some() {
+                for _ in 0..MAXIMUM_TARNSACTION_TIME {
                     match d.is_connected().unwrap_or(true) {
                         true => thread::sleep(Duration::from_millis(CONNECTION_TIMEOUT_MS)),
                         false => return drop(sender.send(Ok(false))),


### PR DESCRIPTION
Added 30 seconds maximum timeout as specified in the bluetooth 4.2 https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=286439 (p. 480). With this the existing bluetooth_device_disconnect.html tests does not show the `connected:t rue` message, before the connection established, and does not show the `connected: false` message, before disconnected form the GATT server.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
-  [x] These changes do not require tests because, there are no webbluetooth test api implementation yet.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
