### PR TITLE
Remove some unnecessary pub modifiers

### DIFF
--- a/components/script/dom/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetoothremotegattcharacteristic.rs
@@ -76,7 +76,7 @@ impl BluetoothRemoteGATTCharacteristic {
         global_ref.as_window().bluetooth_thread()
     }
 
-    pub fn get_instance_id(&self) -> String {
+    fn get_instance_id(&self) -> String {
         self.instanceID.clone()
     }
 }

--- a/components/script/dom/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetoothremotegattdescriptor.rs
@@ -63,7 +63,7 @@ impl BluetoothRemoteGATTDescriptor {
         global_ref.as_window().bluetooth_thread()
     }
 
-    pub fn get_instance_id(&self) -> String {
+    fn get_instance_id(&self) -> String {
         self.instanceID.clone()
     }
 }

--- a/components/script/dom/bluetoothremotegattservice.rs
+++ b/components/script/dom/bluetoothremotegattservice.rs
@@ -63,7 +63,7 @@ impl BluetoothRemoteGATTService {
         global_ref.as_window().bluetooth_thread()
     }
 
-    pub fn get_instance_id(&self) -> String {
+    fn get_instance_id(&self) -> String {
         self.instanceID.clone()
     }
 }


### PR DESCRIPTION
Removed unnecessary pub modifiers from DOM class functions `get_instance_id`.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
