### PR TITLE
Change the error handling as proposed

### DIFF
--- a/components/net/bluetooth_thread.rs
+++ b/components/net/bluetooth_thread.rs
@@ -483,7 +483,7 @@ impl BluetoothManager {
                 }
                 return drop(sender.send(Err(BluetoothError::Network)));
             },
-            None => return drop(sender.send(Err(BluetoothError::Network))),
+            None => return drop(sender.send(Err(BluetoothError::NotFound))),
         }
     }
 
@@ -504,7 +504,7 @@ impl BluetoothManager {
                 }
                 return drop(sender.send(Err(BluetoothError::Network)));
             },
-            None => return drop(sender.send(Err(BluetoothError::Network))),
+            None => return drop(sender.send(Err(BluetoothError::NotFound))),
         }
     }
 

--- a/components/script/bluetooth_blacklist.rs
+++ b/components/script/bluetooth_blacklist.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::error::Error;
-use net_traits::bluetooth_thread::BluetoothError;
 use regex::Regex;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -123,14 +122,4 @@ fn parse_blacklist() -> Option<HashMap<String, Blacklist>> {
     }
     // Step 5
     return Some(result);
-}
-
-pub fn handle_bluetooth_error(error: BluetoothError) -> Error {
-    match error {
-        BluetoothError::Type(message) => Error::Type(message),
-        BluetoothError::Network => Error::Network,
-        BluetoothError::NotFound => Error::NotFound,
-        BluetoothError::NotSupported => Error::NotSupported,
-        BluetoothError::Security => Error::Security,
-    }
 }

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use bluetooth_utils::{Blacklist, handle_bluetooth_error, uuid_is_blacklisted};
+use bluetooth_utils::{Blacklist, uuid_is_blacklisted};
 use core::clone::Clone;
 use dom::bindings::codegen::Bindings::BluetoothBinding;
 use dom::bindings::codegen::Bindings::BluetoothBinding::RequestDeviceOptions;
 use dom::bindings::codegen::Bindings::BluetoothBinding::{BluetoothScanFilter, BluetoothMethods};
-use dom::bindings::error::Error::{Security, Type};
+use dom::bindings::error::Error::{self, Security, Type};
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::Root;
@@ -19,7 +19,7 @@ use dom::bluetoothuuid::BluetoothUUID;
 use ipc_channel::ipc::{self, IpcSender};
 use net_traits::bluetooth_scanfilter::{BluetoothScanfilter, BluetoothScanfilterSequence};
 use net_traits::bluetooth_scanfilter::{RequestDeviceoptions, ServiceUUIDSequence};
-use net_traits::bluetooth_thread::BluetoothMethodMsg;
+use net_traits::bluetooth_thread::{BluetoothError, BluetoothMethodMsg};
 
 const FILTER_EMPTY_ERROR: &'static str = "'filters' member must be non - empty to find any devices.";
 const FILTER_ERROR: &'static str = "A filter must restrict the devices in some way.";
@@ -135,6 +135,18 @@ fn convert_request_device_options(options: &RequestDeviceOptions,
                                  ServiceUUIDSequence::new(optional_services)))
 }
 
+impl From<BluetoothError> for Error {
+    fn from(error: BluetoothError) -> Self {
+        match error {
+            BluetoothError::Type(message) => Error::Type(message),
+            BluetoothError::Network => Error::Network,
+            BluetoothError::NotFound => Error::NotFound,
+            BluetoothError::NotSupported => Error::NotSupported,
+            BluetoothError::Security => Error::Security,
+        }
+    }
+}
+
 impl BluetoothMethods for Bluetooth {
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-requestdevice
     fn RequestDevice(&self, option: &RequestDeviceOptions) -> Fallible<Root<BluetoothDevice>> {
@@ -154,7 +166,7 @@ impl BluetoothMethods for Bluetooth {
                                         &ad_data))
             },
             Err(error) => {
-                Err(handle_bluetooth_error(error))
+                Err(Error::from(error))
             },
         }
     }

--- a/components/script/dom/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetoothremotegattcharacteristic.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use bluetooth_utils::{Blacklist, handle_bluetooth_error, uuid_is_blacklisted};
+use bluetooth_utils::{Blacklist, uuid_is_blacklisted};
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::BluetoothCharacteristicPropertiesBinding::
     BluetoothCharacteristicPropertiesMethods;
@@ -12,7 +12,7 @@ use dom::bindings::codegen::Bindings::BluetoothRemoteGATTCharacteristicBinding::
     BluetoothRemoteGATTCharacteristicMethods;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerMethods;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServiceBinding::BluetoothRemoteGATTServiceMethods;
-use dom::bindings::error::Error::{InvalidModification, Network, NotSupported, Security};
+use dom::bindings::error::Error::{self, InvalidModification, Network, NotSupported, Security};
 use dom::bindings::error::{Fallible, ErrorResult};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, MutHeap, Root};
@@ -115,7 +115,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
                                                       descriptor.instance_id))
             },
             Err(error) => {
-                Err(handle_bluetooth_error(error))
+                Err(Error::from(error))
             },
         }
     }
@@ -147,7 +147,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
                                  .collect())
             },
             Err(error) => {
-                Err(handle_bluetooth_error(error))
+                Err(Error::from(error))
             },
         }
     }
@@ -177,7 +177,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
                 ByteString::new(val)
             },
             Err(error) => {
-                return Err(handle_bluetooth_error(error))
+                return Err(Error::from(error))
             },
         };
         *self.value.borrow_mut() = Some(value.clone());
@@ -202,7 +202,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
         match result {
             Ok(_) => Ok(()),
             Err(error) => {
-                Err(handle_bluetooth_error(error))
+                Err(Error::from(error))
             },
         }
     }

--- a/components/script/dom/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetoothremotegattdescriptor.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use bluetooth_utils::{Blacklist, handle_bluetooth_error, uuid_is_blacklisted};
+use bluetooth_utils::{Blacklist, uuid_is_blacklisted};
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::BluetoothDeviceBinding::BluetoothDeviceMethods;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTCharacteristicBinding::
@@ -11,7 +11,7 @@ use dom::bindings::codegen::Bindings::BluetoothRemoteGATTDescriptorBinding;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTDescriptorBinding::BluetoothRemoteGATTDescriptorMethods;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerMethods;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServiceBinding::BluetoothRemoteGATTServiceMethods;
-use dom::bindings::error::Error::{InvalidModification, Network, Security};
+use dom::bindings::error::Error::{self, InvalidModification, Network, Security};
 use dom::bindings::error::{Fallible, ErrorResult};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, MutHeap, Root};
@@ -101,7 +101,7 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
                 ByteString::new(val)
             },
             Err(error) => {
-                return Err(handle_bluetooth_error(error))
+                return Err(Error::from(error))
             },
         };
         *self.value.borrow_mut() = Some(value.clone());
@@ -126,7 +126,7 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
         match result {
             Ok(_) => Ok(()),
             Err(error) => {
-                Err(handle_bluetooth_error(error))
+                Err(Error::from(error))
             },
         }
     }

--- a/components/script/dom/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetoothremotegattserver.rs
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use bluetooth_utils::{Blacklist, handle_bluetooth_error, uuid_is_blacklisted};
+use bluetooth_utils::{Blacklist, uuid_is_blacklisted};
 use dom::bindings::codegen::Bindings::BluetoothDeviceBinding::BluetoothDeviceMethods;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerMethods;
-use dom::bindings::error::Error::Security;
+use dom::bindings::error::Error::{self, Security};
 use dom::bindings::error::{Fallible, ErrorResult};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, MutHeap, Root};
@@ -72,7 +72,7 @@ impl BluetoothRemoteGATTServerMethods for BluetoothRemoteGATTServer {
                 Ok(Root::from_ref(self))
             },
             Err(error) => {
-                Err(handle_bluetooth_error(error))
+                Err(Error::from(error))
             },
         }
     }
@@ -89,7 +89,7 @@ impl BluetoothRemoteGATTServerMethods for BluetoothRemoteGATTServer {
                 Ok(())
             },
             Err(error) => {
-                Err(handle_bluetooth_error(error))
+                Err(Error::from(error))
             },
         }
     }
@@ -113,7 +113,7 @@ impl BluetoothRemoteGATTServerMethods for BluetoothRemoteGATTServer {
                                                    service.instance_id))
             },
             Err(error) => {
-                Err(handle_bluetooth_error(error))
+                Err(Error::from(error))
             },
         }
     }
@@ -146,7 +146,7 @@ impl BluetoothRemoteGATTServerMethods for BluetoothRemoteGATTServer {
                               .collect())
             },
             Err(error) => {
-                Err(handle_bluetooth_error(error))
+                Err(Error::from(error))
             },
         }
     }

--- a/components/script/dom/bluetoothremotegattservice.rs
+++ b/components/script/dom/bluetoothremotegattservice.rs
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use bluetooth_utils::{Blacklist, handle_bluetooth_error, uuid_is_blacklisted};
+use bluetooth_utils::{Blacklist, uuid_is_blacklisted};
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServiceBinding;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServiceBinding::BluetoothRemoteGATTServiceMethods;
-use dom::bindings::error::Error::Security;
+use dom::bindings::error::Error::{self, Security};
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, MutHeap, Root};
@@ -115,7 +115,7 @@ impl BluetoothRemoteGATTServiceMethods for BluetoothRemoteGATTService {
                                                           characteristic.instance_id))
             },
             Err(error) => {
-                Err(handle_bluetooth_error(error))
+                Err(Error::from(error))
             },
         }
     }
@@ -160,7 +160,7 @@ impl BluetoothRemoteGATTServiceMethods for BluetoothRemoteGATTService {
                 Ok(characteristics)
             },
             Err(error) => {
-                Err(handle_bluetooth_error(error))
+                Err(Error::from(error))
             },
         }
     }
@@ -188,7 +188,7 @@ impl BluetoothRemoteGATTServiceMethods for BluetoothRemoteGATTService {
                                                    service.instance_id))
             },
             Err(error) => {
-                Err(handle_bluetooth_error(error))
+                Err(Error::from(error))
             },
         }
     }
@@ -223,7 +223,7 @@ impl BluetoothRemoteGATTServiceMethods for BluetoothRemoteGATTService {
                               .collect())
             },
             Err(error) => {
-                Err(handle_bluetooth_error(error))
+                Err(Error::from(error))
             },
         }
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Replace two `NetWork` error with `NotFound` error, and replace `handle_bluetooth_error` method with the `From<BluetoothError>` trait implementation.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
