### PR TITLE
Annotations for WebBluetooth webidl  functions

### DIFF
--- a/components/net/bluetooth_thread.rs
+++ b/components/net/bluetooth_thread.rs
@@ -597,6 +597,7 @@ impl BluetoothManager {
         let _ = sender.send(Ok(services_vec));
     }
 
+    // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattservice-getincludedservice
     fn get_included_service(&mut self,
                             service_id: String,
                             uuid: String,
@@ -605,11 +606,15 @@ impl BluetoothManager {
             Some(a) => a,
             None => return drop(sender.send(Err(BluetoothError::Type(ADAPTER_ERROR.to_string())))),
         };
+
+        // Step 4.
         let primary_service = match self.get_gatt_service(&mut adapter, &service_id) {
             Some(s) => s,
             None => return drop(sender.send(Err(BluetoothError::NotFound))),
         };
         let services = primary_service.get_includes().unwrap_or(vec!());
+
+        // Step 5.
         for service in services {
             if let Ok(service_uuid) = service.get_uuid() {
                 if uuid == service_uuid {
@@ -624,6 +629,7 @@ impl BluetoothManager {
         return drop(sender.send(Err(BluetoothError::NotFound)));
     }
 
+    // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattservice-getincludedservices
     fn get_included_services(&mut self,
                              service_id: String,
                              uuid: Option<String>,
@@ -632,11 +638,15 @@ impl BluetoothManager {
             Some(a) => a,
             None => return drop(sender.send(Err(BluetoothError::Type(ADAPTER_ERROR.to_string())))),
         };
+
+        // Step 4.
         let primary_service = match self.get_gatt_service(&mut adapter, &service_id) {
             Some(s) => s,
             None => return drop(sender.send(Err(BluetoothError::NotFound))),
         };
         let services = primary_service.get_includes().unwrap_or(vec!());
+
+        // Step 5.
         let mut services_vec = vec!();
         for service in services {
             if let Ok(service_uuid) = service.get_uuid() {
@@ -657,15 +667,18 @@ impl BluetoothManager {
         let _ = sender.send(Ok(services_vec));
     }
 
+    // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattservice-getcharacteristic
     fn get_characteristic(&mut self,
                           service_id: String,
                           uuid: String,
                           sender: IpcSender<BluetoothResult<BluetoothCharacteristicMsg>>) {
         let mut adapter = get_adapter_or_return_error!(self, sender);
+        // Step 4.
         let characteristics = self.get_gatt_characteristics_by_uuid(&mut adapter, &service_id, &uuid);
         if characteristics.is_empty() {
             return drop(sender.send(Err(BluetoothError::NotFound)));
         }
+        // Step 5.
         for characteristic in characteristics {
             if let Ok(uuid) = characteristic.get_uuid() {
                 let properties = self.get_characteristic_properties(&characteristic);
@@ -688,11 +701,13 @@ impl BluetoothManager {
         return drop(sender.send(Err(BluetoothError::NotFound)));
     }
 
+    // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattservice-getcharacteristic
     fn get_characteristics(&mut self,
                            service_id: String,
                            uuid: Option<String>,
                            sender: IpcSender<BluetoothResult<BluetoothCharacteristicsMsg>>) {
         let mut adapter = get_adapter_or_return_error!(self, sender);
+        // Step 4.
         let characteristics = match uuid {
             Some(id) => self.get_gatt_characteristics_by_uuid(&mut adapter, &service_id, &id),
             None => self.get_and_cache_gatt_characteristics(&mut adapter, &service_id),
@@ -700,6 +715,7 @@ impl BluetoothManager {
         if characteristics.is_empty() {
             return drop(sender.send(Err(BluetoothError::NotFound)));
         }
+        // Step 5.
         let mut characteristics_vec = vec!();
         for characteristic in characteristics {
             if let Ok(uuid) = characteristic.get_uuid() {

--- a/components/net/bluetooth_thread.rs
+++ b/components/net/bluetooth_thread.rs
@@ -798,10 +798,14 @@ impl BluetoothManager {
 
     fn read_value(&mut self, id: String, sender: IpcSender<BluetoothResult<Vec<u8>>>) {
         let mut adapter = get_adapter_or_return_error!(self, sender);
+
         // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-readvalue
         // Step 4.2.
         let mut value = self.get_gatt_characteristic(&mut adapter, &id)
                             .map(|c| c.read_value().unwrap_or(vec![]));
+
+        // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattdescriptor-readvalue
+        // Step 4.1.
         if value.is_none() {
             value = self.get_gatt_descriptor(&mut adapter, &id)
                         .map(|d| d.read_value().unwrap_or(vec![]));
@@ -811,10 +815,14 @@ impl BluetoothManager {
 
     fn write_value(&mut self, id: String, value: Vec<u8>, sender: IpcSender<BluetoothResult<bool>>) {
         let mut adapter = get_adapter_or_return_error!(self, sender);
+
         // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-readvalue
         // Step 6.2.
         let mut result = self.get_gatt_characteristic(&mut adapter, &id)
                              .map(|c| c.write_value(value.clone()));
+
+        // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattdescriptor-writevalue
+        // Step 6.1.
         if result.is_none() {
             result = self.get_gatt_descriptor(&mut adapter, &id)
                          .map(|d| d.write_value(value.clone()));

--- a/components/script/dom/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetoothremotegattcharacteristic.rs
@@ -185,7 +185,6 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
         if uuid_is_blacklisted(self.uuid.as_ref(), Blacklist::Reads) {
             return Err(Security)
         }
-        let (sender, receiver) = ipc::channel().unwrap();
 
         // Step 2.
         // TODO(#4282): Reject promise.
@@ -200,6 +199,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
             return Err(NotSupported)
         }
         // Note: Step 4.2 is implemented in components/net/bluetooth_thread.rs in read_value function.
+        let (sender, receiver) = ipc::channel().unwrap();
         self.get_bluetooth_thread().send(
             BluetoothMethodMsg::ReadValue(self.get_instance_id(), sender)).unwrap();
         let result = receiver.recv().unwrap();

--- a/components/script/dom/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetoothremotegattdescriptor.rs
@@ -91,7 +91,6 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
         if uuid_is_blacklisted(self.uuid.as_ref(), Blacklist::Reads) {
             return Err(Security)
         }
-        let (sender, receiver) = ipc::channel().unwrap();
         // Step 2.
         // TODO(#4282): Reject promise.
         if !self.Characteristic().Service().Device().Gatt().Connected() {
@@ -101,6 +100,7 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
         // TODO(#4282): Step 4: connection-checking-wraper.
 
         // Note: Step 4.1 is implemented in components/net/bluetooth_thread.rs in write_value function.
+        let (sender, receiver) = ipc::channel().unwrap();
         self.get_bluetooth_thread().send(
             BluetoothMethodMsg::ReadValue(self.get_instance_id(), sender)).unwrap();
         let result = receiver.recv().unwrap();

--- a/components/script/dom/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetoothremotegattdescriptor.rs
@@ -86,13 +86,21 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattdescriptor-readvalue
     fn ReadValue(&self) -> Fallible<ByteString> {
+        // Step 1.
+        // TODO(#4282): Reject promise.
         if uuid_is_blacklisted(self.uuid.as_ref(), Blacklist::Reads) {
             return Err(Security)
         }
         let (sender, receiver) = ipc::channel().unwrap();
+        // Step 2.
+        // TODO(#4282): Reject promise.
         if !self.Characteristic().Service().Device().Gatt().Connected() {
             return Err(Network)
         }
+
+        // TODO(#4282): Step 4: connection-checking-wraper.
+
+        // Note: Step 4.1 is implemented in components/net/bluetooth_thread.rs in write_value function.
         self.get_bluetooth_thread().send(
             BluetoothMethodMsg::ReadValue(self.get_instance_id(), sender)).unwrap();
         let result = receiver.recv().unwrap();
@@ -100,31 +108,64 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
             Ok(val) => {
                 ByteString::new(val)
             },
+            // Step 4.2.
+            // TODO(#4282): Reject promise.
             Err(error) => {
                 return Err(Error::from(error))
             },
         };
+
+        // TODO(#4282): Step 4.3.1: activeAlgorithms.
+
+        // Step 4.3.2.
+        // TODO(#9530, #5014): DataView, ArrayBuffer.
         *self.value.borrow_mut() = Some(value.clone());
+
+        // Step 4.3.3.
+        // TODO(#4282): Resolve promise.
         Ok(value)
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattdescriptor-writevalue
     fn WriteValue(&self, value: Vec<u8>) -> ErrorResult {
+        // Step 1.
+        // TODO(#4282): Reject promise.
         if uuid_is_blacklisted(self.uuid.as_ref(), Blacklist::Writes) {
             return Err(Security)
         }
+
+        // TODO(#5014): Step 3: ArrayBuffer.
+
+        // Step 4.
+        // TODO(#4282): Reject promise.
         if value.len() > MAXIMUM_ATTRIBUTE_LENGTH {
             return Err(InvalidModification)
         }
+
+        // Step 5.
+        // TODO(#4282): Reject promise.
         if !self.Characteristic().Service().Device().Gatt().Connected() {
             return Err(Network)
         }
+
+        // TODO(#4282): Step 6: connection-checking-wraper.
+
+        // Note: Step 6.1 is implemented in components/net/bluetooth_thread.rs in write_value function.
         let (sender, receiver) = ipc::channel().unwrap();
         self.get_bluetooth_thread().send(
             BluetoothMethodMsg::WriteValue(self.get_instance_id(), value, sender)).unwrap();
         let result = receiver.recv().unwrap();
+
+        // TODO(#4282): Step 6.3.1: activeAlgorithms.
+
         match result {
+            // Step 6.3.3.
+            // TODO(#4282): Resolve promise.
             Ok(_) => Ok(()),
+            // TODO(#9530, #5014): Step 6.3.2: DataView, ArrayBuffer.
+
+            // Step 6.2.
+            // TODO(#4282): Reject promise.
             Err(error) => {
                 Err(Error::from(error))
             },

--- a/components/script/dom/bluetoothremotegattservice.rs
+++ b/components/script/dom/bluetoothremotegattservice.rs
@@ -88,14 +88,25 @@ impl BluetoothRemoteGATTServiceMethods for BluetoothRemoteGATTService {
     fn GetCharacteristic(&self,
                          characteristic: BluetoothCharacteristicUUID)
                          -> Fallible<Root<BluetoothRemoteGATTCharacteristic>> {
+        // Step 1.
+        // TODO(#4282): Reject promise.
         let uuid = try!(BluetoothUUID::GetCharacteristic(self.global().r(), characteristic)).to_string();
+
+        // Step 2.
+        // TODO(#4282): Reject promise.
         if uuid_is_blacklisted(uuid.as_ref(), Blacklist::All) {
             return Err(Security)
         }
+
+        // Note: Step 4 and a part of the Step 5 are implemented in
+        // components/net/bluetooth_thread.rs in get_characteristic function.
         let (sender, receiver) = ipc::channel().unwrap();
         self.get_bluetooth_thread().send(
             BluetoothMethodMsg::GetCharacteristic(self.get_instance_id(), uuid, sender)).unwrap();
         let characteristic = receiver.recv().unwrap();
+
+        // Step 5.
+        // TODO(#4282): Transforming promise.
         match characteristic {
             Ok(characteristic) => {
                 let properties = BluetoothCharacteristicProperties::new(self.global().r(),
@@ -124,20 +135,30 @@ impl BluetoothRemoteGATTServiceMethods for BluetoothRemoteGATTService {
     fn GetCharacteristics(&self,
                           characteristic: Option<BluetoothCharacteristicUUID>)
                           -> Fallible<Vec<Root<BluetoothRemoteGATTCharacteristic>>> {
+        // Step 1.
+        // TODO(#4282): Reject promise.
         let mut uuid: Option<String> = None;
         if let Some(c) = characteristic {
             uuid = Some(try!(BluetoothUUID::GetCharacteristic(self.global().r(), c)).to_string());
             if let Some(ref uuid) = uuid {
+                // Step 2.
+                // TODO(#4282): Reject promise.
                 if uuid_is_blacklisted(uuid.as_ref(), Blacklist::All) {
                     return Err(Security)
                 }
             }
         };
+
+        // Note: Step 4 and a part of the Step 5 are implemented in
+        // components/net/bluetooth_thread.rs in get_characteristics function.
         let mut characteristics = vec!();
         let (sender, receiver) = ipc::channel().unwrap();
         self.get_bluetooth_thread().send(
             BluetoothMethodMsg::GetCharacteristics(self.get_instance_id(), uuid, sender)).unwrap();
         let characteristics_vec = receiver.recv().unwrap();
+
+        // Step 5.
+        // TODO(#4282): Transforming promise.
         match characteristics_vec {
             Ok(characteristic_vec) => {
                 for characteristic in characteristic_vec {
@@ -169,16 +190,27 @@ impl BluetoothRemoteGATTServiceMethods for BluetoothRemoteGATTService {
     fn GetIncludedService(&self,
                           service: BluetoothServiceUUID)
                           -> Fallible<Root<BluetoothRemoteGATTService>> {
+        // Step 1.
+        // TODO(#4282): Reject promise.
         let uuid = try!(BluetoothUUID::GetService(self.global().r(), service)).to_string();
+
+        // Step 2.
+        // TODO(#4282): Reject promise.
         if uuid_is_blacklisted(uuid.as_ref(), Blacklist::All) {
             return Err(Security)
         }
+
+        // Note: Step 4 and a part of the Step 5 are implemented in
+        // components/net/bluetooth_thread.rs in get_included_service function.
         let (sender, receiver) = ipc::channel().unwrap();
         self.get_bluetooth_thread().send(
             BluetoothMethodMsg::GetIncludedService(self.get_instance_id(),
                                                    uuid,
                                                    sender)).unwrap();
         let service = receiver.recv().unwrap();
+
+        // Step 5.
+        // TODO(#4282): Transforming promise.
         match service {
             Ok(service) => {
                 Ok(BluetoothRemoteGATTService::new(self.global().r(),
@@ -197,21 +229,31 @@ impl BluetoothRemoteGATTServiceMethods for BluetoothRemoteGATTService {
     fn GetIncludedServices(&self,
                           service: Option<BluetoothServiceUUID>)
                           -> Fallible<Vec<Root<BluetoothRemoteGATTService>>> {
+        // Step 1.
+        // TODO(#4282): Reject promise.
         let mut uuid: Option<String> = None;
         if let Some(s) = service {
             uuid = Some(try!(BluetoothUUID::GetService(self.global().r(), s)).to_string());
             if let Some(ref uuid) = uuid {
+                // Step 2.
+                // TODO(#4282): Reject promise.
                 if uuid_is_blacklisted(uuid.as_ref(), Blacklist::All) {
                     return Err(Security)
                 }
             }
         };
+
+        // Note: Step 4 and a part of the Step 5 are implemented in
+        // components/net/bluetooth_thread.rs in get_included_services function.
         let (sender, receiver) = ipc::channel().unwrap();
         self.get_bluetooth_thread().send(
             BluetoothMethodMsg::GetIncludedServices(self.get_instance_id(),
                                                     uuid,
                                                     sender)).unwrap();
         let services_vec = receiver.recv().unwrap();
+
+        // Step 5.
+        // TODO(#4282): Transforming promise.
         match services_vec {
             Ok(service_vec) => {
                 Ok(service_vec.into_iter()


### PR DESCRIPTION
Step annotations for the WebBluetooth webidl functions, excluding `requestDevice` and unimplmeneted methods.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #12614
