### PR TITLE
Further Test api fixes

### DIFF
--- a/components/net/bluetooth_test.rs
+++ b/components/net/bluetooth_test.rs
@@ -221,15 +221,18 @@ fn create_heart_rate_service(device: &BluetoothDevice,
                                               vec![3]));
 
     // Body Sensor Location Characteristic 1
-    let _body_sensor_location_characteristic_1 =
+    let body_sensor_location_characteristic_1 =
         try!(create_characteristic_with_value(&heart_rate_service,
                                               BODY_SENSOR_LOCATION_CHARACTERISTIC_UUID.to_owned(),
-                                              vec![1]));
+                                              vec![49]));
+    try!(body_sensor_location_characteristic_1.set_flags(vec![READ_FLAG.to_string()]));
+
     // Body Sensor Location Characteristic 2
-    let _body_sensor_location_characteristic_2 =
+    let body_sensor_location_characteristic_2 =
         try!(create_characteristic_with_value(&heart_rate_service,
                                               BODY_SENSOR_LOCATION_CHARACTERISTIC_UUID.to_owned(),
-                                              vec![2]));
+                                              vec![50]));
+    try!(body_sensor_location_characteristic_2.set_flags(vec![READ_FLAG.to_string()]));
     Ok(heart_rate_service)
 }
 
@@ -252,10 +255,17 @@ fn create_generic_access_service(device: &BluetoothDevice,
     try!(device_name_characteristic.set_flags(vec![READ_FLAG.to_string(), WRITE_FLAG.to_string()]));
 
     // Number of Digitals descriptor
-    let _number_of_digitals_descriptor =
+    let number_of_digitals_descriptor_1 =
         try!(create_descriptor_with_value(&device_name_characteristic,
                                           NUMBER_OF_DIGITALS_UUID.to_owned(),
-                                          vec![49, 49]));
+                                          vec![49; 2]));
+    try!(number_of_digitals_descriptor_1.set_flags(vec![READ_FLAG.to_string(), WRITE_FLAG.to_string()]));
+
+    let number_of_digitals_descriptor_2 =
+        try!(create_descriptor_with_value(&device_name_characteristic,
+                                          NUMBER_OF_DIGITALS_UUID.to_owned(),
+                                          vec![42; 2]));
+    try!(number_of_digitals_descriptor_2.set_flags(vec![READ_FLAG.to_string(), WRITE_FLAG.to_string()]));
 
     // Characteristic User Description Descriptor
     let _characteristic_user_description =

--- a/components/net/bluetooth_test.rs
+++ b/components/net/bluetooth_test.rs
@@ -109,6 +109,8 @@ const CLIENT_CHARACTERISTIC_CONFIGURATION_UUID: &'static str = "00002902-0000-10
 // viewer?attributeXmlFile=org.bluetooth.descriptor.number_of_digitals.xml
 const NUMBER_OF_DIGITALS_UUID: &'static str = "00002909-0000-1000-8000-00805f9b34fb";
 
+const HEART_RATE_DEVICE_NAME_DESCRIPTION: &'static str = "The name of this device.";
+
 fn generate_id() -> Uuid {
     let mut id = Uuid::nil();
     let mut generated = false;
@@ -218,7 +220,7 @@ fn create_heart_rate_service(device: &BluetoothDevice,
     let _heart_rate_measurement_characteristic =
         try!(create_characteristic_with_value(&heart_rate_service,
                                               HEART_RATE_MEASUREMENT_CHARACTERISTIC_UUID.to_owned(),
-                                              vec![3]));
+                                              vec![0]));
 
     // Body Sensor Location Characteristic 1
     let body_sensor_location_characteristic_1 =
@@ -258,26 +260,26 @@ fn create_generic_access_service(device: &BluetoothDevice,
     let number_of_digitals_descriptor_1 =
         try!(create_descriptor_with_value(&device_name_characteristic,
                                           NUMBER_OF_DIGITALS_UUID.to_owned(),
-                                          vec![49; 2]));
+                                          vec![49]));
     try!(number_of_digitals_descriptor_1.set_flags(vec![READ_FLAG.to_string(), WRITE_FLAG.to_string()]));
 
     let number_of_digitals_descriptor_2 =
         try!(create_descriptor_with_value(&device_name_characteristic,
                                           NUMBER_OF_DIGITALS_UUID.to_owned(),
-                                          vec![42; 2]));
+                                          vec![50]));
     try!(number_of_digitals_descriptor_2.set_flags(vec![READ_FLAG.to_string(), WRITE_FLAG.to_string()]));
 
     // Characteristic User Description Descriptor
     let _characteristic_user_description =
         try!(create_descriptor_with_value(&device_name_characteristic,
                                           CHARACTERISTIC_USER_DESCRIPTION_UUID.to_owned(),
-                                          vec![22, 33, 44, 55]));
+                                          HEART_RATE_DEVICE_NAME_DESCRIPTION.as_bytes().to_vec()));
 
     // Client Characteristic Configuration descriptor
     let _client_characteristic_configuration =
         try!(create_descriptor_with_value(&device_name_characteristic,
                                           CLIENT_CHARACTERISTIC_CONFIGURATION_UUID.to_owned(),
-                                          vec![0, 0]));
+                                          vec![0]));
 
     // Peripheral Privacy Flag Characteristic
     let peripheral_privacy_flag_characteristic =
@@ -358,17 +360,17 @@ fn create_two_heart_rate_services_device(adapter: &BluetoothAdapter) -> Result<(
     let _heart_rate_measurement_characteristic =
         try!(create_characteristic_with_value(&heart_rate_service_empty_1,
                                               HEART_RATE_MEASUREMENT_CHARACTERISTIC_UUID.to_owned(),
-                                              vec![3]));
+                                              vec![0]));
 
     let _body_sensor_location_characteristic_1 =
         try!(create_characteristic_with_value(&heart_rate_service_empty_1,
                                               BODY_SENSOR_LOCATION_CHARACTERISTIC_UUID.to_owned(),
-                                              vec![1]));
+                                              vec![49]));
 
     let _body_sensor_location_characteristic_2 =
         try!(create_characteristic_with_value(&heart_rate_service_empty_2,
                                               BODY_SENSOR_LOCATION_CHARACTERISTIC_UUID.to_owned(),
-                                              vec![2]));
+                                              vec![50]));
     Ok(())
 }
 
@@ -394,12 +396,12 @@ fn create_blacklisted_device(adapter: &BluetoothAdapter) -> Result<(), Box<Error
     let _blacklist_exclude_reads_descriptor =
         try!(create_descriptor_with_value(&blacklist_exclude_reads_characteristic,
                                           BLACKLIST_EXCLUDE_READS_DESCRIPTOR_UUID.to_owned(),
-                                          vec![054, 054, 054]));
+                                          vec![54; 3]));
 
     let _blacklist_descriptor =
         try!(create_descriptor_with_value(&blacklist_exclude_reads_characteristic,
                                           BLACKLIST_DESCRIPTOR_UUID.to_owned(),
-                                          vec![054, 054, 054]));
+                                          vec![54; 3]));
 
     let device_information_service = try!(create_service(&connectable_device, DEVICE_INFORMATION_UUID.to_owned()));
 

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/connect/device-goes-out-of-range.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/connect/device-goes-out-of-range.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Device goes out of range. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristic/device-goes-out-of-range.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristic/device-goes-out-of-range.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Device goes out of range. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristic/disconnect-called-before.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristic/disconnect-called-before.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [disconnect() called before getCharacteristic. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristic/disconnect-called-during.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristic/disconnect-called-during.html.ini
@@ -1,5 +1,5 @@
 [disconnect-called-during.html]
   type: testharness
   prefs: [dom.bluetooth.testing.enabled:true]
-  [disconnect() called before getCharacteristic. Reject with NetworkError.]
+  [disconnect() called during getCharacteristic. Reject with NetworkError.]
     expected: FAIL

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristic/disconnect-called-during.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristic/disconnect-called-during.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [disconnect() called before getCharacteristic. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristic/get-same-characteristic.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristic/get-same-characteristic.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Calls to get the same characteristic should return the same object.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristic/service-is-removed.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristic/service-is-removed.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Service is removed. Reject with InvalidStateError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/blacklisted-characteristics.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/blacklisted-characteristics.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [The Device Information service is composed of blacklisted characteristics so we shouldn't find any.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/device-goes-out-of-range-with-uuid.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/device-goes-out-of-range-with-uuid.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Device goes out of range with UUID. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/device-goes-out-of-range.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/device-goes-out-of-range.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Device goes out of range. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/disconnect-called-before-with-uuid.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/disconnect-called-before-with-uuid.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [disconnect() called before getCharacteristics. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/disconnect-called-before.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/disconnect-called-before.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [disconnect() called before getCharacteristics. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/disconnect-called-during-with-uuid.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/disconnect-called-during-with-uuid.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [disconnect() called before getCharacteristics. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/disconnect-called-during-with-uuid.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/disconnect-called-during-with-uuid.html.ini
@@ -1,5 +1,5 @@
 [disconnect-called-during-with-uuid.html]
   type: testharness
   prefs: [dom.bluetooth.testing.enabled:true]
-  [disconnect() called before getCharacteristics. Reject with NetworkError.]
+  [disconnect() called during getCharacteristics. Reject with NetworkError.]
     expected: FAIL

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/disconnect-called-during.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/disconnect-called-during.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [disconnect() called before getCharacteristics. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/disconnect-called-during.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/disconnect-called-during.html.ini
@@ -1,5 +1,5 @@
 [disconnect-called-during.html]
   type: testharness
   prefs: [dom.bluetooth.testing.enabled:true]
-  [disconnect() called before getCharacteristics. Reject with NetworkError.]
+  [disconnect() called during getCharacteristics. Reject with NetworkError.]
     expected: FAIL

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/get-same-characteristics.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/get-same-characteristics.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Calls to get the same characteristics should return the same objects.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/service-is-removed-with-uuid.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/service-is-removed-with-uuid.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Service is removed. Reject with InvalidStateError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/service-is-removed.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/service-is-removed.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Service is removed. Reject with InvalidStateError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptor/characteristic-is-removed.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptor/characteristic-is-removed.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Characteristic is removed. Reject with InvalidStateError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptor/device-goes-out-of-range.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptor/device-goes-out-of-range.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Device goes out of range. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptor/disconnect-called-before.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptor/disconnect-called-before.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [disconnect() called before getDescriptor. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptor/disconnect-called-during.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptor/disconnect-called-during.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [disconnect() called before getDescriptor. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptor/disconnect-called-during.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptor/disconnect-called-during.html.ini
@@ -1,5 +1,5 @@
 [disconnect-called-during.html]
   type: testharness
   prefs: [dom.bluetooth.testing.enabled:true]
-  [disconnect() called before getDescriptor. Reject with NetworkError.]
+  [disconnect() called during getDescriptor. Reject with NetworkError.]
     expected: FAIL

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptor/get-same-descriptor.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptor/get-same-descriptor.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Calls to get the same descriptor should return the same object.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/blacklisted-descriptors.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/blacklisted-descriptors.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [The descriptors are blacklisted.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/characteristic-is-removed-with-uuid.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/characteristic-is-removed-with-uuid.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Characteristic is removed. Reject with InvalidStateError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/characteristic-is-removed.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/characteristic-is-removed.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Characteristic is removed. Reject with InvalidStateError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/device-goes-out-of-range-with-uuid.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/device-goes-out-of-range-with-uuid.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Device goes out of range. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/device-goes-out-of-range.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/device-goes-out-of-range.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Device goes out of range. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/disconnect-called-before-with-uuid.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/disconnect-called-before-with-uuid.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [disconnect() called before getDescriptors. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/disconnect-called-before.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/disconnect-called-before.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [disconnect() called before getDescriptors. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/disconnect-called-during-with-uuid.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/disconnect-called-during-with-uuid.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [disconnect() called before getDescriptors. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/disconnect-called-during-with-uuid.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/disconnect-called-during-with-uuid.html.ini
@@ -1,5 +1,5 @@
 [disconnect-called-during-with-uuid.html]
   type: testharness
   prefs: [dom.bluetooth.testing.enabled:true]
-  [disconnect() called before getDescriptors. Reject with NetworkError.]
+  [disconnect() called during getDescriptors. Reject with NetworkError.]
     expected: FAIL

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/disconnect-called-during.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/disconnect-called-during.html.ini
@@ -1,5 +1,5 @@
 [disconnect-called-during.html]
   type: testharness
   prefs: [dom.bluetooth.testing.enabled:true]
-  [disconnect() called before getDescriptors. Reject with NetworkError.]
+  [disconnect() called during getDescriptors. Reject with NetworkError.]
     expected: FAIL

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/disconnect-called-during.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/disconnect-called-during.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [disconnect() called before getDescriptors. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/get-same-descriptors.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getDescriptors/get-same-descriptors.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Calls to get the same descriptor should return the same object.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryService/device-goes-out-of-range.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryService/device-goes-out-of-range.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Device goes out of range. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryService/disconnect-called-before.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryService/disconnect-called-before.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [disconnect() called before getPrimaryService. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryService/disconnect-called-during.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryService/disconnect-called-during.html.ini
@@ -1,5 +1,5 @@
 [disconnect-called-during.html]
   type: testharness
   prefs: [dom.bluetooth.testing.enabled:true]
-  [disconnect() called before getPrimaryService. Reject with NetworkError.]
+  [disconnect() called during getPrimaryService. Reject with NetworkError.]
     expected: FAIL

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryService/disconnect-called-during.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryService/disconnect-called-during.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [disconnect() called before getPrimaryService. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryService/disconnected-device.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryService/disconnected-device.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [getPrimaryService called before connecting. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryService/get-same-service.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryService/get-same-service.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Calls to get the same service should return the same object.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/blacklisted-services.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/blacklisted-services.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Request for services. Does not return blacklisted service.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/device-goes-out-of-range-with-uuid.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/device-goes-out-of-range-with-uuid.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Device goes out of range. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/device-goes-out-of-range.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/device-goes-out-of-range.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Device goes out of range. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/disconnect-called-before-with-uuid.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/disconnect-called-before-with-uuid.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [disconnect() called before getPrimaryServices. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/disconnect-called-before.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/disconnect-called-before.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [disconnect() called before getPrimaryServices. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/disconnect-called-during-with-uuid.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/disconnect-called-during-with-uuid.html.ini
@@ -1,5 +1,5 @@
 [disconnect-called-during-with-uuid.html]
   type: testharness
   prefs: [dom.bluetooth.testing.enabled:true]
-  [disconnect() called before getPrimaryServices. Reject with NetworkError.]
+  [disconnect() called during getPrimaryServices. Reject with NetworkError.]
     expected: FAIL

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/disconnect-called-during-with-uuid.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/disconnect-called-during-with-uuid.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [disconnect() called before getPrimaryServices. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/disconnect-called-during.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/disconnect-called-during.html.ini
@@ -1,5 +1,5 @@
 [disconnect-called-during.html]
   type: testharness
   prefs: [dom.bluetooth.testing.enabled:true]
-  [disconnect() called before getPrimaryServices. Reject with NetworkError.]
+  [disconnect() called during getPrimaryServices. Reject with NetworkError.]
     expected: FAIL

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/disconnect-called-during.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/disconnect-called-during.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [disconnect() called before getPrimaryServices. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/disconnected-device-with-uuid.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/disconnected-device-with-uuid.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [getPrimaryServices called before connecting. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/disconnected-device.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/disconnected-device.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [getPrimaryServices called before connecting. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/get-same-service.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/get-same-service.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Calls to get the same service should return the same object.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/no-permission-present-service.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getPrimaryServices/no-permission-present-service.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Request for present service without permission. Reject with NotFoundError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/readValue/characteristic/characteristic-is-removed.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/readValue/characteristic/characteristic-is-removed.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Characteristic gets removed. Reject with InvalidStateError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/readValue/characteristic/device-goes-out-of-range.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/readValue/characteristic/device-goes-out-of-range.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Device goes out of range. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/readValue/characteristic/service-is-removed.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/readValue/characteristic/service-is-removed.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Service gets removed. Reject with InvalidStateError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/readValue/descriptor/characteristic-is-removed.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/readValue/descriptor/characteristic-is-removed.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Characteristic gets removed. Reject with InvalidStateError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/readValue/descriptor/descriptor-is-removed.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/readValue/descriptor/descriptor-is-removed.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Descriptor gets removed. Reject with InvalidStateError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/readValue/descriptor/device-goes-out-of-range.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/readValue/descriptor/device-goes-out-of-range.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Device goes out of range. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/readValue/descriptor/service-is-removed.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/readValue/descriptor/service-is-removed.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Service gets removed. Reject with InvalidStateError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/adapter-not-present.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/adapter-not-present.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Reject with NotFoundError if the adapter is not present.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/adapter-off.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/adapter-off.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Reject with NotFoundError if the adapter is off.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/canonicalizeFilter/max-length-for-name-in-adv-name.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/canonicalizeFilter/max-length-for-name-in-adv-name.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [A device name longer than 29 must reject.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/canonicalizeFilter/max-length-for-name-in-adv-namePrefix.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/canonicalizeFilter/max-length-for-name-in-adv-namePrefix.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [A device name prefix longer than 29 must reject.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/canonicalizeFilter/unicode-max-length-for-name-in-adv-name.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/canonicalizeFilter/unicode-max-length-for-name-in-adv-name.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Unicode string with utf8 representation between (29, 248\] bytes in 'name' must throw NotFoundError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/canonicalizeFilter/unicode-max-length-for-name-in-adv-namePrefix.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/canonicalizeFilter/unicode-max-length-for-name-in-adv-namePrefix.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Unicode string with utf8 representation between (29, 248\] bytes in 'namePrefix' must throw NotFoundError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/correct-uuids.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/correct-uuids.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [We should only see UUID's that we've been given permission for.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/name-empty-device-from-name-empty-filter.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/name-empty-device-from-name-empty-filter.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [An empty name device can be obtained by empty name filter.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/name-empty-filter.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/name-empty-filter.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [A named device is not matched by a filter with an empty name.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/name-missing-device-from-name-empty-filter.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/name-missing-device-from-name-empty-filter.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [An unnamed device can not be obtained by empty name filter.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/same-device.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/requestDevice/same-device.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Returned device should always be the same.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/writeValue/characteristic/characteristic-is-removed.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/writeValue/characteristic/characteristic-is-removed.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Characteristic gets removed. Reject with InvalidStateError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/writeValue/characteristic/device-goes-out-of-range.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/writeValue/characteristic/device-goes-out-of-range.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Device goes out of range. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/writeValue/characteristic/service-is-removed.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/writeValue/characteristic/service-is-removed.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Service gets removed. Reject with InvalidStateError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/writeValue/characteristic/write-updates-value.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/writeValue/characteristic/write-updates-value.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [A regular write request to a writable characteristic should update value.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/writeValue/descriptor/characteristic-is-removed.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/writeValue/descriptor/characteristic-is-removed.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Characteristic gets removed. Reject with InvalidStateError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/writeValue/descriptor/descriptor-is-removed.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/writeValue/descriptor/descriptor-is-removed.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Descriptor gets removed. Reject with InvalidStateError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/writeValue/descriptor/device-goes-out-of-range.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/writeValue/descriptor/device-goes-out-of-range.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Device goes out of range. Reject with NetworkError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/writeValue/descriptor/service-is-removed.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/writeValue/descriptor/service-is-removed.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [Service gets removed. Reject with InvalidStateError.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/writeValue/descriptor/write-updates-value.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/writeValue/descriptor/write-updates-value.html.ini
@@ -3,4 +3,3 @@
   prefs: [dom.bluetooth.testing.enabled:true]
   [A regular write request to a writable descriptor should update value.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/connect/connection-succeeds.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/connect/connection-succeeds.html
@@ -10,7 +10,6 @@ promise_test(() => {
         filters: [{services: [heart_rate.name]}]
     })
     .then(device => device.gatt.connect())
-    .then(gattServer => assert_true(gattServer.connected))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(gattServer => assert_true(gattServer.connected));
 }, 'Device will connect');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/connect/device-goes-out-of-range.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/connect/device-goes-out-of-range.html
@@ -12,7 +12,6 @@ promise_test(t => {
     .then(device => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.empty);
         return promise_rejects(t, 'NetworkError', device.gatt.connect());
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Device goes out of range. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/connect/get-same-gatt-server.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/connect/get-same-gatt-server.html
@@ -10,7 +10,6 @@ promise_test(() => {
         filters: [{services: [heart_rate.name]}]
     })
     .then(device => Promise.all([device.gatt.connect(), device.gatt.connect()]))
-    .then(gattServers => assert_equals(gattServers[0], gattServers[1]))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(gattServers => assert_equals(gattServers[0], gattServers[1]));
 }, 'Multiple connects should return the same gatt object.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/disconnect/connect-disconnect-twice.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/disconnect/connect-disconnect-twice.html
@@ -21,7 +21,6 @@ promise_test(() => {
             gattServer.disconnect();
             assert_false(gattServer.connected);
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Connect + Disconnect twice still results in \'connected\' being false.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/disconnect/disconnect-once.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/disconnect/disconnect-once.html
@@ -14,7 +14,6 @@ promise_test(() => {
         assert_true(gattServer.connected);
         gattServer.disconnect();
         assert_false(gattServer.connected);
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, '\'connected\' is set to false after disconnect is called.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/disconnect/disconnect-twice-in-a-row.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/disconnect/disconnect-twice-in-a-row.html
@@ -16,7 +16,6 @@ promise_test(() => {
         assert_false(gattServer.connected);
         gattServer.disconnect();
         assert_false(gattServer.connected);
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Calling disconnect twice in a row still results in \'connected\' ' + 'being false.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/blacklisted-characteristic.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/blacklisted-characteristic.html
@@ -11,7 +11,6 @@ promise_test(t => {
     })
     .then(device => device.gatt.connect())
     .then(gattServer => gattServer.getPrimaryService(device_information.name))
-    .then(service => promise_rejects(t, 'SecurityError', service.getCharacteristic(serial_number_string.name)))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(service => promise_rejects(t, 'SecurityError', service.getCharacteristic(serial_number_string.name)));
 }, 'Serial Number String characteristic is blacklisted.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/characteristic-found.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/characteristic-found.html
@@ -27,7 +27,6 @@ promise_test(() => {
                     'Characteristic service should be the same as service.');
             });
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Request for characteristic. Should return right characteristic');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/characteristic-not-found.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/characteristic-not-found.html
@@ -12,7 +12,6 @@ promise_test(t => {
     })
     .then(device => device.gatt.connect())
     .then(gattServer => gattServer.getPrimaryService(generic_access.name))
-    .then(service => promise_rejects(t, 'NotFoundError', service.getCharacteristic(battery_level.name)))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(service => promise_rejects(t, 'NotFoundError', service.getCharacteristic(battery_level.name)));
 }, 'Request for absent characteristic. Reject with NotFoundError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/device-goes-out-of-range.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/device-goes-out-of-range.html
@@ -15,7 +15,6 @@ promise_test(t => {
     .then(service => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.empty);
         return promise_rejects(t, 'NetworkError', service.getCharacteristic(device_name.uuid));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Device goes out of range. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/disconnect-called-before.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/disconnect-called-before.html
@@ -17,7 +17,6 @@ promise_test(t => {
             gattServer.disconnect();
             return promise_rejects(t, 'NetworkError', service.getCharacteristic(device_name.uuid));
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before getCharacteristic. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/disconnect-called-during.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/disconnect-called-during.html
@@ -18,7 +18,6 @@ promise_test(t => {
             gattServer.disconnect();
             return promise;
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before getCharacteristic. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/disconnect-called-during.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/disconnect-called-during.html
@@ -19,5 +19,5 @@ promise_test(t => {
             return promise;
         });
     });
-}, 'disconnect() called before getCharacteristic. Reject with NetworkError.');
+}, 'disconnect() called during getCharacteristic. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/get-same-characteristic.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/get-same-characteristic.html
@@ -22,7 +22,6 @@ promise_test(() => {
                     'Should return the same characteristic as the first call.');
             }
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Calls to get the same characteristic should return the same object.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/invalid-characteristic-name.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/invalid-characteristic-name.html
@@ -12,7 +12,6 @@ promise_test(t => {
     })
     .then(device => device.gatt.connect())
     .then(gattServer => gattServer.getPrimaryService(generic_access.name))
-    .then(service => promise_rejects(t, 'SyntaxError', service.getCharacteristic(wrong.name)))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(service => promise_rejects(t, 'SyntaxError', service.getCharacteristic(wrong.name)));
 }, 'Wrong Characteristic name. Reject with SyntaxError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/service-is-removed.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/service-is-removed.html
@@ -15,7 +15,6 @@ promise_test(t => {
     .then(service => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.missing_service_heart_rate);
         return promise_rejects(t, 'InvalidStateError', service.getCharacteristic(device_name.uuid));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Service is removed. Reject with InvalidStateError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/blacklisted-characteristics-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/blacklisted-characteristics-with-uuid.html
@@ -11,7 +11,6 @@ promise_test(t => {
     })
     .then(device => device.gatt.connect())
     .then(gattServer => gattServer.getPrimaryService(device_information.name))
-    .then(service => promise_rejects(t, 'SecurityError', service.getCharacteristics(serial_number_string.name)))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(service => promise_rejects(t, 'SecurityError', service.getCharacteristics(serial_number_string.name)));
 }, 'Serial Number String characteristic is blacklisted. Should reject with SecurityError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/blacklisted-characteristics.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/blacklisted-characteristics.html
@@ -11,7 +11,6 @@ promise_test(t => {
     })
     .then(device => device.gatt.connect())
     .then(gattServer => gattServer.getPrimaryService(device_information.name))
-    .then(service => promise_rejects(t, 'NotFoundError', service.getCharacteristics()))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(service => promise_rejects(t, 'NotFoundError', service.getCharacteristics()));
 }, 'The Device Information service is composed of blacklisted characteristics so we shouldn\'t find any.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/characteristics-found-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/characteristics-found-with-uuid.html
@@ -23,7 +23,6 @@ promise_test(() => {
                 assert_equals(characteristics[1].uuid, body_sensor_location.uuid);
             });
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Find characteristics with UUID in service.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/characteristics-found.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/characteristics-found.html
@@ -17,7 +17,6 @@ promise_test(() => {
         assert_equals(characteristics[0].uuid, heart_rate_measurement.uuid);
         assert_equals(characteristics[1].uuid, body_sensor_location.uuid);
         assert_equals(characteristics[2].uuid, body_sensor_location.uuid);
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Find all characteristics in a service.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/characteristics-not-found-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/characteristics-not-found-with-uuid.html
@@ -11,7 +11,6 @@ promise_test(t => {
     })
     .then(device => device.gatt.connect())
     .then(gattServer => gattServer.getPrimaryService(heart_rate.name))
-    .then(service => promise_rejects(t, 'NotFoundError', service.getCharacteristics(battery_level.name)))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(service => promise_rejects(t, 'NotFoundError', service.getCharacteristics(battery_level.name)));
 }, 'Request for absent characteristics with UUID. Reject with NotFoundError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/characteristics-not-found.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/characteristics-not-found.html
@@ -11,7 +11,6 @@ promise_test(t => {
     })
     .then(device => device.gatt.connect())
     .then(gattServer => gattServer.getPrimaryService(heart_rate.name))
-    .then(service => promise_rejects(t, 'NotFoundError', service.getCharacteristics()))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(service => promise_rejects(t, 'NotFoundError', service.getCharacteristics()));
 }, 'Request for absent characteristics. Reject with NotFoundError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/correct-characteristics.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/correct-characteristics.html
@@ -12,14 +12,15 @@ promise_test(() => {
     .then(device => device.gatt.connect())
     .then(gattServer => gattServer.getPrimaryService(heart_rate.name))
     .then(service => service.getCharacteristics(body_sensor_location.name))
-    .then(characteristics => {
-        for (let i = 1; i < characteristics.length; i++) {
-            characteristics[i].readValue()
-            .then(value => {
-                assert_equals(value.byteLength, 1);
-                assert_equals(value.getUint8(0), i);
-            })
-        }
+    .then(characteristics => Promise.all([
+        characteristics[0].readValue(),
+        characteristics[1].readValue()]))
+    .then(value_arrays => {
+            assert_equals(value_arrays.length, 2);
+            assert_equals(value_arrays[0].length, 1);
+            assert_equals(value_arrays[0], '1');
+            assert_equals(value_arrays[1].length, 1);
+            assert_equals(value_arrays[1], '2');
     });
 }, 'Find characteristics with UUID in service.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/correct-characteristics.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/correct-characteristics.html
@@ -20,7 +20,6 @@ promise_test(() => {
                 assert_equals(value.getUint8(0), i);
             })
         }
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Find characteristics with UUID in service.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/device-goes-out-of-range-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/device-goes-out-of-range-with-uuid.html
@@ -14,7 +14,6 @@ promise_test(t => {
     .then(service => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.empty);
         return promise_rejects(t, 'NetworkError', service.getCharacteristics(heart_rate_measurement.name));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Device goes out of range with UUID. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/device-goes-out-of-range.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/device-goes-out-of-range.html
@@ -14,7 +14,6 @@ promise_test(t => {
     .then(service => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.empty);
         return promise_rejects(t, 'NetworkError', service.getCharacteristics());
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Device goes out of range. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/disconnect-called-before-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/disconnect-called-before-with-uuid.html
@@ -16,7 +16,6 @@ promise_test(t => {
             gattServer.disconnect();
             return promise_rejects(t, 'NetworkError', service.getCharacteristics(body_sensor_location.alias));
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before getCharacteristics. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/disconnect-called-before.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/disconnect-called-before.html
@@ -16,7 +16,6 @@ promise_test(t => {
             gattServer.disconnect();
             return promise_rejects(t, 'NetworkError', service.getCharacteristics());
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before getCharacteristics. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/disconnect-called-during-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/disconnect-called-during-with-uuid.html
@@ -18,6 +18,6 @@ promise_test(t => {
             return promise;
         });
     });
-}, 'disconnect() called before getCharacteristics. Reject with NetworkError.');
+}, 'disconnect() called during getCharacteristics. Reject with NetworkError.');
 </script>
 

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/disconnect-called-during-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/disconnect-called-during-with-uuid.html
@@ -17,8 +17,7 @@ promise_test(t => {
             gattServer.disconnect();
             return promise;
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before getCharacteristics. Reject with NetworkError.');
 </script>
 

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/disconnect-called-during.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/disconnect-called-during.html
@@ -17,7 +17,6 @@ promise_test(t => {
             gattServer.disconnect();
             return promise;
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before getCharacteristics. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/disconnect-called-during.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/disconnect-called-during.html
@@ -18,5 +18,5 @@ promise_test(t => {
             return promise;
         });
     });
-}, 'disconnect() called before getCharacteristics. Reject with NetworkError.');
+}, 'disconnect() called during getCharacteristics. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/get-same-characteristics.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/get-same-characteristics.html
@@ -21,7 +21,6 @@ promise_test(() => {
         for (let i = 0; i < chars1.length; i++) {
             assert_equals(chars1[i], chars2[i]);
         }
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Calls to get the same characteristics should return the same objects.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/invalid-characteristic-name.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/invalid-characteristic-name.html
@@ -12,7 +12,6 @@ promise_test(t => {
     })
     .then(device => device.gatt.connect())
     .then(gattServer => gattServer.getPrimaryService(generic_access.name))
-    .then(service => promise_rejects(t, 'SyntaxError', service.getCharacteristics(wrong.name)))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(service => promise_rejects(t, 'SyntaxError', service.getCharacteristics(wrong.name)));
 }, 'Invalid Characteristic name. Reject with SyntaxError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/service-is-removed-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/service-is-removed-with-uuid.html
@@ -14,7 +14,6 @@ promise_test(t => {
     .then(service => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.missing_service_heart_rate);
         return promise_rejects(t, 'InvalidStateError', service.getCharacteristic(heart_rate_measurement.name));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Service is removed. Reject with InvalidStateError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/service-is-removed.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/service-is-removed.html
@@ -14,7 +14,6 @@ promise_test(t => {
     .then(service => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.missing_service_heart_rate);
         return promise_rejects(t, 'InvalidStateError', service.getCharacteristics());
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Service is removed. Reject with InvalidStateError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/blacklisted-descriptor.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/blacklisted-descriptor.html
@@ -13,7 +13,6 @@ promise_test(t => {
     .then(gattServer => gattServer.getPrimaryService(blacklist_test_service_uuid))
     .then(service => service.getCharacteristic(blacklist_exclude_reads_characteristic_uuid))
     .then(characteristic => promise_rejects(t, 'SecurityError',
-                                            characteristic.getDescriptor(blacklist_descriptor_uuid)))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+                                            characteristic.getDescriptor(blacklist_descriptor_uuid)));
 }, 'The descriptor is blacklisted.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/characteristic-is-removed.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/characteristic-is-removed.html
@@ -16,7 +16,6 @@ promise_test(t => {
     .then(characteristic => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.missing_characteristic_heart_rate);
         return promise_rejects(t, 'InvalidStateError', characteristic.getDescriptor(number_of_digitals.name));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Characteristic is removed. Reject with InvalidStateError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/descriptor-found.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/descriptor-found.html
@@ -28,7 +28,6 @@ promise_test(() => {
                     'Descriptor characteristic should be the same as characteristic.');
             });
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Request for descriptor. Should return right descriptor');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/descriptor-not-found.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/descriptor-not-found.html
@@ -13,7 +13,6 @@ promise_test(t => {
     .then(device => device.gatt.connect())
     .then(gattServer => gattServer.getPrimaryService(generic_access.name))
     .then(service => service.getCharacteristic(device_name.name))
-    .then(characteristic => promise_rejects(t, 'NotFoundError', characteristic.getDescriptor(number_of_digitals.name)))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(characteristic => promise_rejects(t, 'NotFoundError', characteristic.getDescriptor(number_of_digitals.name)));
 }, 'Request for absent descriptor. Reject with NotFoundError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/device-goes-out-of-range.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/device-goes-out-of-range.html
@@ -16,7 +16,6 @@ promise_test(t => {
     .then(characteristic => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.empty);
         return promise_rejects(t, 'NetworkError', characteristic.getDescriptor(number_of_digitals.name));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Device goes out of range. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/disconnect-called-before.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/disconnect-called-before.html
@@ -18,7 +18,6 @@ promise_test(t => {
             gattServer.disconnect();
             return promise_rejects(t, 'NetworkError', characteristic.getDescriptor(number_of_digitals.name));
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before getDescriptor. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/disconnect-called-during.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/disconnect-called-during.html
@@ -20,5 +20,5 @@ promise_test(t => {
             return promise;
         });
     });
-}, 'disconnect() called before getDescriptor. Reject with NetworkError.');
+}, 'disconnect() called during getDescriptor. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/disconnect-called-during.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/disconnect-called-during.html
@@ -19,7 +19,6 @@ promise_test(t => {
             gattServer.disconnect();
             return promise;
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before getDescriptor. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/get-same-descriptor.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/get-same-descriptor.html
@@ -23,7 +23,6 @@ promise_test(() => {
                     'Should return the same descriptor as the first call.');
             }
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Calls to get the same descriptor should return the same object.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/invalid-descriptor-name.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/invalid-descriptor-name.html
@@ -13,7 +13,6 @@ promise_test(t => {
     .then(device => device.gatt.connect())
     .then(gattServer => gattServer.getPrimaryService(generic_access.name))
     .then(service => service.getCharacteristic(device_name.name))
-    .then(characteristic => promise_rejects(t, 'SyntaxError', characteristic.getDescriptor(wrong.name)))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(characteristic => promise_rejects(t, 'SyntaxError', characteristic.getDescriptor(wrong.name)));
 }, 'Wrong descriptor name. Reject with SyntaxError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/blacklisted-descriptors-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/blacklisted-descriptors-with-uuid.html
@@ -13,7 +13,6 @@ promise_test(t => {
     .then(gattServer => gattServer.getPrimaryService(blacklist_test_service_uuid))
     .then(service => service.getCharacteristic(blacklist_exclude_reads_characteristic_uuid))
     .then(characteristic => promise_rejects(t, 'SecurityError',
-                                            characteristic.getDescriptors(blacklist_descriptor_uuid)))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+                                            characteristic.getDescriptors(blacklist_descriptor_uuid)));
 }, 'The descriptor is blacklisted. Should reject with SecurityError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/blacklisted-descriptors.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/blacklisted-descriptors.html
@@ -12,7 +12,6 @@ promise_test(t => {
     .then(device => device.gatt.connect())
     .then(gattServer => gattServer.getPrimaryService(blacklist_test_service_uuid))
     .then(service => service.getCharacteristic(blacklist_exclude_reads_characteristic_uuid))
-    .then(characteristic => promise_rejects(t, 'NotFoundError', characteristic.getDescriptors()))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(characteristic => promise_rejects(t, 'NotFoundError', characteristic.getDescriptors()));
 }, 'The descriptors are blacklisted.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/characteristic-is-removed-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/characteristic-is-removed-with-uuid.html
@@ -16,7 +16,6 @@ promise_test(t => {
     .then(characteristic => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.missing_characteristic_heart_rate);
         return promise_rejects(t, 'InvalidStateError', characteristic.getDescriptors(number_of_digitals.name));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Characteristic is removed. Reject with InvalidStateError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/characteristic-is-removed.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/characteristic-is-removed.html
@@ -16,7 +16,6 @@ promise_test(t => {
     .then(characteristic => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.missing_characteristic_heart_rate);
         return promise_rejects(t, 'InvalidStateError', characteristic.getDescriptors());
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Characteristic is removed. Reject with InvalidStateError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/correct-descriptors.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/correct-descriptors.html
@@ -18,10 +18,10 @@ promise_test(() => {
         descriptors[1].readValue()]))
     .then(value_arrays => {
             assert_equals(value_arrays.length, 2);
-            assert_equals(value_arrays[0].length, 2);
-            assert_equals(value_arrays[0], '11');
-            assert_equals(value_arrays[1].length, 2);
-            assert_equals(value_arrays[1], '**');
+            assert_equals(value_arrays[0].length, 1);
+            assert_equals(value_arrays[0], '1');
+            assert_equals(value_arrays[1].length, 1);
+            assert_equals(value_arrays[1], '2');
     });
 }, 'Find descriptors with UUID in service.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/correct-descriptors.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/correct-descriptors.html
@@ -13,14 +13,15 @@ promise_test(() => {
     .then(gattServer => gattServer.getPrimaryService(generic_access.name))
     .then(service => service.getCharacteristic(device_name.name))
     .then(characteristic => characteristic.getDescriptors(number_of_digitals.name))
-    .then(descriptors => {
-        for (let i = 1; i < descriptors.length; i++) {
-            descriptors[i].readValue()
-            .then(value => {
-                assert_equals(value.byteLength, 2);
-                assert_equals(value.getUint8(0), 11);
-            })
-        }
+    .then(descriptors => Promise.all([
+        descriptors[0].readValue(),
+        descriptors[1].readValue()]))
+    .then(value_arrays => {
+            assert_equals(value_arrays.length, 2);
+            assert_equals(value_arrays[0].length, 2);
+            assert_equals(value_arrays[0], '11');
+            assert_equals(value_arrays[1].length, 2);
+            assert_equals(value_arrays[1], '**');
     });
 }, 'Find descriptors with UUID in service.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/correct-descriptors.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/correct-descriptors.html
@@ -21,7 +21,6 @@ promise_test(() => {
                 assert_equals(value.getUint8(0), 11);
             })
         }
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Find descriptors with UUID in service.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/descriptors-found-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/descriptors-found-with-uuid.html
@@ -24,7 +24,6 @@ promise_test(() => {
                 assert_equals(descriptors[0].uuid, number_of_digitals.uuid);
             });
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Find descriptors with UUID in service.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/descriptors-found-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/descriptors-found-with-uuid.html
@@ -20,8 +20,9 @@ promise_test(() => {
             characteristic.getDescriptors(number_of_digitals.uuid)])
         .then(descriptors_arrays => {
             descriptors_arrays.forEach(descriptors => {
-                assert_equals(descriptors.length, 1);
+                assert_equals(descriptors.length, 2);
                 assert_equals(descriptors[0].uuid, number_of_digitals.uuid);
+                assert_equals(descriptors[1].uuid, number_of_digitals.uuid);
             });
         });
     });

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/descriptors-found.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/descriptors-found.html
@@ -19,7 +19,6 @@ promise_test(() => {
         assert_equals(descriptors[0].uuid, number_of_digitals.uuid);
         assert_equals(descriptors[1].uuid, characteristic_user_description_uuid);
         assert_equals(descriptors[2].uuid, client_characteristic_configuration.uuid);
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Find descriptors with UUID in service.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/descriptors-found.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/descriptors-found.html
@@ -15,10 +15,11 @@ promise_test(() => {
     .then(service => service.getCharacteristic(device_name.name))
     .then(characteristic => characteristic.getDescriptors())
     .then(descriptors => {
-        assert_equals(descriptors.length, 3);
+        assert_equals(descriptors.length, 4);
         assert_equals(descriptors[0].uuid, number_of_digitals.uuid);
-        assert_equals(descriptors[1].uuid, characteristic_user_description_uuid);
-        assert_equals(descriptors[2].uuid, client_characteristic_configuration.uuid);
+        assert_equals(descriptors[1].uuid, number_of_digitals.uuid);
+        assert_equals(descriptors[2].uuid, characteristic_user_description_uuid);
+        assert_equals(descriptors[3].uuid, client_characteristic_configuration.uuid);
     });
 }, 'Find descriptors with UUID in service.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/descriptors-not-found-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/descriptors-not-found-with-uuid.html
@@ -14,7 +14,6 @@ promise_test(t => {
     .then(gattServer => gattServer.getPrimaryService(generic_access.name))
     .then(service => service.getCharacteristic(device_name.name))
     .then(characteristic => promise_rejects(t, 'NotFoundError',
-                                            characteristic.getDescriptors(number_of_digitals.name)))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+                                            characteristic.getDescriptors(number_of_digitals.name)));
 }, 'Request for absent descriptors with UUID. Reject with NotFoundError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/descriptors-not-found.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/descriptors-not-found.html
@@ -14,7 +14,6 @@ promise_test(t => {
     .then(gattServer => gattServer.getPrimaryService(generic_access.name))
     .then(service => service.getCharacteristic(device_name.name))
     .then(characteristic => promise_rejects(t, 'NotFoundError',
-                                            characteristic.getDescriptors()))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+                                            characteristic.getDescriptors()));
 }, 'Request for absent descriptors with UUID. Reject with NotFoundError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/device-goes-out-of-range-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/device-goes-out-of-range-with-uuid.html
@@ -16,7 +16,6 @@ promise_test(t => {
     .then(characteristic => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.empty);
         return promise_rejects(t, 'NetworkError', characteristic.getDescriptors(number_of_digitals.name));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Device goes out of range. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/device-goes-out-of-range.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/device-goes-out-of-range.html
@@ -16,7 +16,6 @@ promise_test(t => {
     .then(characteristic => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.empty);
         return promise_rejects(t, 'NetworkError', characteristic.getDescriptors());
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Device goes out of range. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/disconnect-called-before-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/disconnect-called-before-with-uuid.html
@@ -18,7 +18,6 @@ promise_test(t => {
             gattServer.disconnect();
             return promise_rejects(t, 'NetworkError', characteristic.getDescriptors(number_of_digitals.alias));
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before getDescriptors. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/disconnect-called-before.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/disconnect-called-before.html
@@ -18,7 +18,6 @@ promise_test(t => {
             gattServer.disconnect();
             return promise_rejects(t, 'NetworkError', characteristic.getDescriptors());
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before getDescriptors. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/disconnect-called-during-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/disconnect-called-during-with-uuid.html
@@ -19,7 +19,6 @@ promise_test(t => {
             gattServer.disconnect();
             return promise;
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before getDescriptors. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/disconnect-called-during-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/disconnect-called-during-with-uuid.html
@@ -20,5 +20,5 @@ promise_test(t => {
             return promise;
         });
     });
-}, 'disconnect() called before getDescriptors. Reject with NetworkError.');
+}, 'disconnect() called during getDescriptors. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/disconnect-called-during.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/disconnect-called-during.html
@@ -19,7 +19,6 @@ promise_test(t => {
             gattServer.disconnect();
             return promise;
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before getDescriptors. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/disconnect-called-during.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/disconnect-called-during.html
@@ -20,5 +20,5 @@ promise_test(t => {
             return promise;
         });
     });
-}, 'disconnect() called before getDescriptors. Reject with NetworkError.');
+}, 'disconnect() called during getDescriptors. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/get-same-descriptors.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/get-same-descriptors.html
@@ -23,7 +23,6 @@ promise_test(() => {
         for (let i = 0; i < descs1.length; i++) {
             assert_equals(descs1[i], descs2[i]);
         }
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Calls to get the same descriptor should return the same object.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/invalid-descriptor-name.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/invalid-descriptor-name.html
@@ -13,7 +13,6 @@ promise_test(t => {
     .then(device => device.gatt.connect())
     .then(gattServer => gattServer.getPrimaryService(generic_access.name))
     .then(service => service.getCharacteristic(device_name.name))
-    .then(characteristic => promise_rejects(t, 'SyntaxError', characteristic.getDescriptors(wrong.name)))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(characteristic => promise_rejects(t, 'SyntaxError', characteristic.getDescriptors(wrong.name)));
 }, 'Wrong descriptor name. Reject with SyntaxError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/device-goes-out-of-range.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/device-goes-out-of-range.html
@@ -13,7 +13,6 @@ promise_test(t => {
     .then(gattServer => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.empty);
         return promise_rejects(t, 'NetworkError', gattServer.getPrimaryService(generic_access.name));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Device goes out of range. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/disconnect-called-before.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/disconnect-called-before.html
@@ -13,7 +13,6 @@ promise_test(t => {
     .then(gattServer => {
         gattServer.disconnect();
         return promise_rejects(t, 'NetworkError', gattServer.getPrimaryService(heart_rate.name));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before getPrimaryService. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/disconnect-called-during.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/disconnect-called-during.html
@@ -15,5 +15,5 @@ promise_test(t => {
         gattServer.disconnect();
         return promise;
     });
-}, 'disconnect() called before getPrimaryService. Reject with NetworkError.');
+}, 'disconnect() called during getPrimaryService. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/disconnect-called-during.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/disconnect-called-during.html
@@ -14,7 +14,6 @@ promise_test(t => {
         let promise = promise_rejects(t, 'NetworkError', gattServer.getPrimaryService(heart_rate.name));
         gattServer.disconnect();
         return promise;
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before getPrimaryService. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/disconnected-device.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/disconnected-device.html
@@ -9,7 +9,6 @@ promise_test(t => {
     return window.navigator.bluetooth.requestDevice({
         filters: [{services: [heart_rate.name]}]
     })
-    .then(device => promise_rejects(t, 'NetworkError', device.gatt.getPrimaryService(heart_rate.name)))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(device => promise_rejects(t, 'NetworkError', device.gatt.getPrimaryService(heart_rate.name)));
 }, 'getPrimaryService called before connecting. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/get-same-service.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/get-same-service.html
@@ -19,7 +19,6 @@ promise_test(() => {
             assert_equals(services[0], services[i],
                           'Should return the same service as the first call.');
         }
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Calls to get the same service should return the same object.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/invalid-service-name.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/invalid-service-name.html
@@ -10,7 +10,6 @@ promise_test(t => {
         filters: [{services: [heart_rate.name]}]
     })
     .then(device => device.gatt.connect())
-    .then(gattServer => promise_rejects(t, 'SyntaxError', gattServer.getPrimaryService(wrong.name)))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(gattServer => promise_rejects(t, 'SyntaxError', gattServer.getPrimaryService(wrong.name)));
 }, 'Wrong Service name. Reject with SyntaxError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/no-permission-absent-service.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/no-permission-absent-service.html
@@ -14,7 +14,6 @@ promise_test(t => {
     .then(gattServer => Promise.all([
         promise_rejects(t, expected, gattServer.getPrimaryService(glucose.alias)),
         promise_rejects(t, expected, gattServer.getPrimaryService(glucose.name)),
-        promise_rejects(t, expected, gattServer.getPrimaryService(glucose.uuid))]))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+        promise_rejects(t, expected, gattServer.getPrimaryService(glucose.uuid))]));
 }, 'Request for absent service without permission. Reject with SecurityError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/no-permission-present-service.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/no-permission-present-service.html
@@ -14,7 +14,6 @@ promise_test(t => {
     .then(gattServer => Promise.all([
         promise_rejects(t, expected, gattServer.getPrimaryService(generic_access.alias)),
         promise_rejects(t, expected, gattServer.getPrimaryService(generic_access.name)),
-        promise_rejects(t, expected, gattServer.getPrimaryService(generic_access.uuid))]))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+        promise_rejects(t, expected, gattServer.getPrimaryService(generic_access.uuid))]));
 }, 'Request for present service without permission. Reject with SecurityError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/service-found.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/service-found.html
@@ -26,7 +26,6 @@ promise_test(() => {
                               'Service device should be the same as device.');
             });
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Request for service. Should return right service');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/service-not-found.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/service-not-found.html
@@ -11,7 +11,6 @@ promise_test(t => {
         optionalServices: [glucose.name]
     })
     .then(device => device.gatt.connect())
-    .then(gattServer => promise_rejects(t, 'NotFoundError', gattServer.getPrimaryService(glucose.name)))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(gattServer => promise_rejects(t, 'NotFoundError', gattServer.getPrimaryService(glucose.name)));
 }, 'Request for absent service. Reject with NotFoundError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/blacklisted-services-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/blacklisted-services-with-uuid.html
@@ -11,7 +11,6 @@ promise_test(t => {
         optionalServices: [human_interface_device.name]
     })
     .then(device => device.gatt.connect())
-    .then(gattServer => promise_rejects(t, 'SecurityError', gattServer.getPrimaryServices(human_interface_device.name)))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(gattServer => promise_rejects(t, 'SecurityError', gattServer.getPrimaryServices(human_interface_device.name)));
 }, 'Request for services. Does not return blacklisted service.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/blacklisted-services.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/blacklisted-services.html
@@ -21,7 +21,6 @@ promise_test(() => {
         assert_equals(services[1].uuid, device_information.uuid);
         assert_equals(services[2].uuid, generic_access.uuid);
         assert_equals(services[3].uuid, heart_rate.uuid);
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Request for services. Does not return blacklisted service.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/correct-services.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/correct-services.html
@@ -17,7 +17,6 @@ promise_test(() => {
     .then(characteristics_arrays => {
         assert_equals(characteristics_arrays[0].length, 2);
         assert_equals(characteristics_arrays[1].length, 1);
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Find correct services with UUID.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/device-goes-out-of-range-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/device-goes-out-of-range-with-uuid.html
@@ -14,7 +14,6 @@ promise_test(t => {
     .then(gattServer => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.empty);
         return promise_rejects(t, 'NetworkError', gattServer.getPrimaryServices(generic_access.name));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Device goes out of range. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/device-goes-out-of-range.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/device-goes-out-of-range.html
@@ -14,7 +14,6 @@ promise_test(t => {
     .then(gattServer => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.empty);
         return promise_rejects(t, 'NetworkError', gattServer.getPrimaryServices());
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Device goes out of range. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/disconnect-called-before-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/disconnect-called-before-with-uuid.html
@@ -14,7 +14,6 @@ promise_test(t => {
     .then(gattServer => {
         gattServer.disconnect();
         return promise_rejects(t, 'NetworkError', gattServer.getPrimaryServices(heart_rate.name));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before getPrimaryServices. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/disconnect-called-before.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/disconnect-called-before.html
@@ -14,7 +14,6 @@ promise_test(t => {
     .then(gattServer => {
         gattServer.disconnect();
         return promise_rejects(t, 'NetworkError', gattServer.getPrimaryServices());
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before getPrimaryServices. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/disconnect-called-during-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/disconnect-called-during-with-uuid.html
@@ -15,5 +15,5 @@ promise_test(t => {
         gattServer.disconnect();
         return promise;
     });
-}, 'disconnect() called before getPrimaryServices. Reject with NetworkError.');
+}, 'disconnect() called during getPrimaryServices. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/disconnect-called-during-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/disconnect-called-during-with-uuid.html
@@ -14,7 +14,6 @@ promise_test(t => {
         let promise = promise_rejects(t, 'NetworkError', gattServer.getPrimaryServices(heart_rate.name));
         gattServer.disconnect();
         return promise;
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before getPrimaryServices. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/disconnect-called-during.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/disconnect-called-during.html
@@ -15,5 +15,5 @@ promise_test(t => {
         gattServer.disconnect();
         return promise;
     });
-}, 'disconnect() called before getPrimaryServices. Reject with NetworkError.');
+}, 'disconnect() called during getPrimaryServices. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/disconnect-called-during.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/disconnect-called-during.html
@@ -14,7 +14,6 @@ promise_test(t => {
         let promise = promise_rejects(t, 'NetworkError', gattServer.getPrimaryServices());
         gattServer.disconnect();
         return promise;
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before getPrimaryServices. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/disconnected-device-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/disconnected-device-with-uuid.html
@@ -9,7 +9,6 @@ promise_test(t => {
     return window.navigator.bluetooth.requestDevice({
         filters: [{services: [heart_rate.name]}]
     })
-    .then(device => promise_rejects(t, 'NetworkError', device.gatt.getPrimaryServices(heart_rate.name)))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(device => promise_rejects(t, 'NetworkError', device.gatt.getPrimaryServices(heart_rate.name)));
 }, 'getPrimaryServices called before connecting. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/disconnected-device.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/disconnected-device.html
@@ -9,7 +9,6 @@ promise_test(t => {
     return window.navigator.bluetooth.requestDevice({
         filters: [{services: [heart_rate.name]}]
     })
-    .then(device => promise_rejects(t, 'NetworkError', device.gatt.getPrimaryServices()))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(device => promise_rejects(t, 'NetworkError', device.gatt.getPrimaryServices()));
 }, 'getPrimaryServices called before connecting. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/get-same-service.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/get-same-service.html
@@ -19,9 +19,8 @@ promise_test(() => {
         assert_equals(services1.length, services2.length);
         for (let i = 0; i < services1.length; i++) {
             assert_equals(services1[i], services2[i],
-                          'Should return the same service as the first call.');
+            'Should return the same service as the first call.');
         }
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Calls to get the same service should return the same object.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/invalid-service-name.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/invalid-service-name.html
@@ -10,7 +10,6 @@ promise_test(t => {
         filters: [{services: [heart_rate.name]}]
     })
     .then(device => device.gatt.connect())
-    .then(gattServer => promise_rejects(t, 'SyntaxError', gattServer.getPrimaryServices(wrong.name)))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(gattServer => promise_rejects(t, 'SyntaxError', gattServer.getPrimaryServices(wrong.name)));
 }, 'Wrong Service name. Reject with SyntaxError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/no-permission-absent-service-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/no-permission-absent-service-with-uuid.html
@@ -14,7 +14,6 @@ promise_test(t => {
     .then(gattServer => Promise.all([
         promise_rejects(t, expected, gattServer.getPrimaryServices(glucose.alias)),
         promise_rejects(t, expected, gattServer.getPrimaryServices(glucose.name)),
-        promise_rejects(t, expected, gattServer.getPrimaryServices(glucose.uuid))]))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+        promise_rejects(t, expected, gattServer.getPrimaryServices(glucose.uuid))]));
 }, 'Request for absent service without permission. Reject with SecurityError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/no-permission-present-service-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/no-permission-present-service-with-uuid.html
@@ -14,7 +14,6 @@ promise_test(t => {
     .then(gattServer => Promise.all([
         promise_rejects(t, expected, gattServer.getPrimaryServices(generic_access.alias)),
         promise_rejects(t, expected, gattServer.getPrimaryServices(generic_access.name)),
-        promise_rejects(t, expected, gattServer.getPrimaryServices(generic_access.uuid))]))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+        promise_rejects(t, expected, gattServer.getPrimaryServices(generic_access.uuid))]));
 }, 'Request for present service without permission. Reject with SecurityError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/no-permission-present-service.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/no-permission-present-service.html
@@ -10,7 +10,6 @@ promise_test(t => {
         filters: [{name: mock_device_name.heart_rate}]
     })
     .then(device => device.gatt.connect())
-    .then(gattServer => promise_rejects(t, 'NotFoundError', gattServer.getPrimaryServices()))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(gattServer => promise_rejects(t, 'NotFoundError', gattServer.getPrimaryServices()));
 }, 'Request for present service without permission. Reject with NotFoundError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/services-found-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/services-found-with-uuid.html
@@ -22,7 +22,6 @@ promise_test(() => {
             assert_true(services[0].isPrimary);
             assert_true(services[1].isPrimary);
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Request for service. Should return right service');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/services-found.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/services-found.html
@@ -20,7 +20,6 @@ promise_test(() => {
         assert_true(services[0].isPrimary);
         assert_true(services[1].isPrimary);
         assert_true(services[2].isPrimary);
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Find all services in a device.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/services-not-found-with-uuid.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/services-not-found-with-uuid.html
@@ -11,7 +11,6 @@ promise_test(t => {
         optionalServices: [glucose.name]
     })
     .then(device => device.gatt.connect())
-    .then(gattServer => promise_rejects(t, 'NotFoundError', gattServer.getPrimaryServices(glucose.name)))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(gattServer => promise_rejects(t, 'NotFoundError', gattServer.getPrimaryServices(glucose.name)));
 }, 'Request for absent service. Reject with NotFoundError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/services-not-found.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/services-not-found.html
@@ -11,7 +11,6 @@ promise_test(t => {
         optionalServices: [generic_access.name]
     })
     .then(device => device.gatt.connect())
-    .then(gattServer => promise_rejects(t, 'NotFoundError', gattServer.getPrimaryServices()))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(gattServer => promise_rejects(t, 'NotFoundError', gattServer.getPrimaryServices()));
 }, 'Request for absent service. Reject with NotFoundError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/characteristic/blacklisted-characteristic.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/characteristic/blacklisted-characteristic.html
@@ -15,7 +15,6 @@ promise_test(t => {
     .then(characteristic => {
         return characteristic.writeValue(new Uint8Array(1))
         .then(() => promise_rejects(t, 'SecurityError', characteristic.readValue()));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Characteristic with exclude-reads fullfills write and rejects read.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/characteristic/characteristic-is-removed.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/characteristic/characteristic-is-removed.html
@@ -16,7 +16,6 @@ promise_test(t => {
     .then(characteristic => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.missing_characteristic_heart_rate);
         return promise_rejects(t, 'InvalidStateError', characteristic.readValue());
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Characteristic gets removed. Reject with InvalidStateError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/characteristic/device-goes-out-of-range.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/characteristic/device-goes-out-of-range.html
@@ -16,7 +16,6 @@ promise_test(t => {
     .then(characteristic => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.empty);
         return promise_rejects(t, 'NetworkError', characteristic.readValue());
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Device goes out of range. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/characteristic/disconnect-called-before.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/characteristic/disconnect-called-before.html
@@ -18,7 +18,6 @@ promise_test(t => {
             gattServer.disconnect();
             return promise_rejects(t, 'NetworkError', characteristic.readValue());
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before readValue. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/characteristic/read-succeeds.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/characteristic/read-succeeds.html
@@ -14,7 +14,6 @@ promise_test(() => {
     .then(gattServer => gattServer.getPrimaryService(generic_access.name))
     .then(service => service.getCharacteristic(device_name.name))
     .then(characteristic => characteristic.readValue())
-    .then(value => assert_equals(value, mock_device_name.heart_rate))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(value => assert_equals(value, mock_device_name.heart_rate));
 }, 'A read request succeeds and returns the characteristic\'s value.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/characteristic/read-updates-value.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/characteristic/read-updates-value.html
@@ -17,7 +17,6 @@ promise_test(() => {
         assert_equals(characteristic.value, null);
         return characteristic.readValue()
         .then(() => assert_equals(characteristic.value, mock_device_name.heart_rate));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Succesful read should update characteristic.value');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/characteristic/service-is-removed.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/characteristic/service-is-removed.html
@@ -16,7 +16,6 @@ promise_test(t => {
     .then(characteristic => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.missing_service_heart_rate);
         return promise_rejects(t, 'InvalidStateError', characteristic.readValue());
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Service gets removed. Reject with InvalidStateError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/descriptor/blacklisted-descriptor.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/descriptor/blacklisted-descriptor.html
@@ -16,7 +16,6 @@ promise_test(t => {
     .then(descriptor => {
         return descriptor.writeValue(new Uint8Array(1))
         .then(() =>  promise_rejects(t, 'SecurityError', descriptor.readValue()));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Descriptor with exclude-reads fullfills write and rejects read.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/descriptor/characteristic-is-removed.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/descriptor/characteristic-is-removed.html
@@ -17,7 +17,6 @@ promise_test(t => {
     .then(descriptor => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.missing_characteristic_heart_rate);
         return promise_rejects(t, 'InvalidStateError', descriptor.readValue());
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Characteristic gets removed. Reject with InvalidStateError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/descriptor/descriptor-is-removed.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/descriptor/descriptor-is-removed.html
@@ -17,7 +17,6 @@ promise_test(t => {
     .then(descriptor => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.missing_descriptor_heart_rate);
         return promise_rejects(t, 'InvalidStateError', descriptor.readValue());
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Descriptor gets removed. Reject with InvalidStateError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/descriptor/device-goes-out-of-range.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/descriptor/device-goes-out-of-range.html
@@ -17,7 +17,6 @@ promise_test(t => {
     .then(descriptor => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.empty);
         return promise_rejects(t, 'NetworkError', descriptor.readValue());
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Device goes out of range. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/descriptor/disconnect-called-before.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/descriptor/disconnect-called-before.html
@@ -19,7 +19,6 @@ promise_test(t => {
             gattServer.disconnect();
             return promise_rejects(t, 'NetworkError', descriptor.readValue());
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before readValue. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/descriptor/read-succeeds.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/descriptor/read-succeeds.html
@@ -15,6 +15,6 @@ promise_test(() => {
     .then(service => service.getCharacteristic(device_name.name))
     .then(characteristic => characteristic.getDescriptor(number_of_digitals.name))
     .then(descriptor => descriptor.readValue())
-    .then(value => assert_equals(value, '11'));
+    .then(value => assert_equals(value, '1'));
 }, 'A read request succeeds and returns the descriptor\'s value.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/descriptor/read-succeeds.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/descriptor/read-succeeds.html
@@ -15,7 +15,6 @@ promise_test(() => {
     .then(service => service.getCharacteristic(device_name.name))
     .then(characteristic => characteristic.getDescriptor(number_of_digitals.name))
     .then(descriptor => descriptor.readValue())
-    .then(value => assert_equals(value, '11'))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(value => assert_equals(value, '11'));
 }, 'A read request succeeds and returns the descriptor\'s value.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/descriptor/read-updates-value.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/descriptor/read-updates-value.html
@@ -18,7 +18,6 @@ promise_test(() => {
         assert_equals(descriptor.value, null);
         return descriptor.readValue()
         .then(() => assert_equals(descriptor.value, '11'));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Succesful read should update descriptor.value');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/descriptor/read-updates-value.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/descriptor/read-updates-value.html
@@ -17,7 +17,7 @@ promise_test(() => {
     .then(descriptor => {
         assert_equals(descriptor.value, null);
         return descriptor.readValue()
-        .then(() => assert_equals(descriptor.value, '11'));
+        .then(() => assert_equals(descriptor.value, '1'));
     });
 }, 'Succesful read should update descriptor.value');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/descriptor/service-is-removed.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/readValue/descriptor/service-is-removed.html
@@ -17,7 +17,6 @@ promise_test(t => {
     .then(descriptor => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.missing_service_heart_rate);
         return promise_rejects(t, 'InvalidStateError', descriptor.readValue());
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Service gets removed. Reject with InvalidStateError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/blacklisted-service-in-optionalServices.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/blacklisted-service-in-optionalServices.html
@@ -14,7 +14,6 @@ promise_test(t => {
     .then(device => device.gatt.connect())
     .then(gattServer => Promise.all([
           promise_rejects(t, expected, gattServer.getPrimaryService(human_interface_device.name)),
-          promise_rejects(t, expected, gattServer.getPrimaryServices(human_interface_device.name))]))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+          promise_rejects(t, expected, gattServer.getPrimaryServices(human_interface_device.name))]));
 }, 'Blacklisted UUID in optionalServices is removed and access not granted.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/empty-namePrefix.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/empty-namePrefix.html
@@ -33,7 +33,7 @@ promise_test(t => {
     test_specs.forEach(args => {
         test_promises = test_promises
             .then(() => promise_rejects(t, new TypeError(), window.navigator.bluetooth.requestDevice(args)))
-            .catch(error => assert_unreached('Promise should have resolved. ' + error));
+            ;
     });
     return test_promises;
 }, 'requestDevice with empty namePrefix. Should reject with TypeError.');

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/empty-services-member.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/empty-services-member.html
@@ -33,7 +33,7 @@ promise_test(t => {
     test_specs.forEach(args => {
       test_promises = test_promises
         .then(() => promise_rejects(t, new TypeError(), window.navigator.bluetooth.requestDevice(args)))
-        .catch(error => assert_unreached('Promise should have resolved. ' + error));
+        ;
     });
     return test_promises;
 }, 'Services member must contain at least one service.');

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/unicode-valid-length-name-name.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/unicode-valid-length-name-name.html
@@ -13,8 +13,7 @@ promise_test(() => {
     return window.navigator.bluetooth.requestDevice({
         filters: [{name: valid_unicode_name}]
     })
-    .then(device => assert_equals(device.name, valid_unicode_name))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(device => assert_equals(device.name, valid_unicode_name));
 }, 'A name containing unicode characters whose utf8 length is less than 30 ' +
    'must not throw an error.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/unicode-valid-length-name-namePrefix.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/unicode-valid-length-name-namePrefix.html
@@ -12,8 +12,7 @@ promise_test(() => {
     return window.navigator.bluetooth.requestDevice({
         filters: [{namePrefix: valid_unicode_name}]
     })
-    .then(device => assert_equals(device.name, valid_unicode_name))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(device => assert_equals(device.name, valid_unicode_name));
 }, 'A name containing unicode characters whose utf8 length is less than 30 ' +
    'must not throw an error.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-service-in-optionalServices-member.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-service-in-optionalServices-member.html
@@ -34,7 +34,7 @@ promise_test(t => {
         test_promises = test_promises
             .then(() => promise_rejects(
                 t, 'SyntaxError', window.navigator.bluetooth.requestDevice(args)))
-            .catch(error => assert_unreached('Promise should have resolved. ' + error));
+            ;
     });
     return test_promises;
 }, 'Invalid optional service must reject the promise.');

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-service-in-services-member.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-service-in-services-member.html
@@ -33,7 +33,7 @@ promise_test(t => {
         test_promises = test_promises
             .then(() => promise_rejects(
                 t, 'SyntaxError', window.navigator.bluetooth.requestDevice(args)))
-            .catch(error => assert_unreached('Promise should have resolved. ' + error));
+            ;
     });
     return test_promises;
 }, 'Invalid optional service must reject the promise.');

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/correct-uuids.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/correct-uuids.html
@@ -14,7 +14,6 @@ promise_test(() => {
         assert_equals(device.uuids.length, 2);
         assert_in_array(glucose.uuid, device.uuids);
         assert_in_array(tx_power.uuid, device.uuids);
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'We should only see UUID\'s that we\'ve been given permission for.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/discovery-succeeds.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/discovery-succeeds.html
@@ -14,7 +14,6 @@ promise_test(() => {
         devices.forEach(device => {
             assert_true(device instanceof BluetoothDevice);
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Mock will resolve.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/filter-does-not-match.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/filter-does-not-match.html
@@ -90,7 +90,7 @@ promise_test(t => {
         test_promises = test_promises
             .then(() => promise_rejects(
                 t, 'NotFoundError', window.navigator.bluetooth.requestDevice(args)))
-            .catch(error => assert_unreached('Promise should have resolved. ' + error));
+            ;
     });
     return test_promises;
 }, 'If at least one filter member doesn\'t match the promise must reject.');

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/filter-matches.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/filter-matches.html
@@ -58,7 +58,7 @@ promise_test(() => {
                 assert_equals(device.name, matching_name);
                 assert_true(device.name.startsWith(matching_namePrefix));
             })
-            .catch(error => assert_unreached('Promise should have resolved. ' + error));
+            ;
     });
     return test_promises;
 }, 'Matches a filter if all present members match.');

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/name-empty-device-from-name-empty-filter.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/name-empty-device-from-name-empty-filter.html
@@ -10,7 +10,6 @@ promise_test(() => {
         filters: [{name: ''}],
         optionalServices: [generic_access.name]
     })
-    .then(device => assert_equals(device.name, ''))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(device => assert_equals(device.name, ''));
 }, 'An empty name device can be obtained by empty name filter.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/name-empty-device-from-service-filter.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/name-empty-device-from-service-filter.html
@@ -9,7 +9,6 @@ promise_test(() => {
     return window.navigator.bluetooth.requestDevice({
         filters: [{services: [heart_rate.name]}]
     })
-    .then(device => assert_equals(device.name, ''))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(device => assert_equals(device.name, ''));
 }, 'An empty name device can be obtained by advertised service UUID.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/name-missing-device-from-service-filter.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/name-missing-device-from-service-filter.html
@@ -9,7 +9,6 @@ promise_test(() => {
     return window.navigator.bluetooth.requestDevice({
         filters: [{services: [heart_rate.name]}]
     })
-    .then(device => assert_equals(device.name, null))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(device => assert_equals(device.name, null));
 }, 'An unnamed device can be obtained by advertised service UUID.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/same-device.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/same-device.html
@@ -13,7 +13,6 @@ promise_test(() => {
     .then(devices => {
         assert_equals(devices[0], devices[1]);
         assert_equals(devices[1], devices[2]);
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Returned device should always be the same.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/single-filter-single-service.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/single-filter-single-service.html
@@ -9,7 +9,6 @@ promise_test(() => {
     return window.navigator.bluetooth.requestDevice({
         filters: [{services: [glucose.name]}]
     })
-    .then(device => assert_equals(device.name, mock_device_name.glucose))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(device => assert_equals(device.name, mock_device_name.glucose));
 }, 'Simple filter selects matching device.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/single-filter-two-services-succeeds.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/single-filter-two-services-succeeds.html
@@ -9,7 +9,6 @@ promise_test(() => {
     return window.navigator.bluetooth.requestDevice({
         filters: [{services: [glucose.name, tx_power.name]}]
     })
-    .then(device => assert_equals(device.name, mock_device_name.glucose))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(device => assert_equals(device.name, mock_device_name.glucose));
 }, 'Filter with 2 services returns a matching device.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/two-filters.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/two-filters.html
@@ -10,7 +10,6 @@ promise_test(() => {
         filters: [{services: [battery_service.name]},
                   {services: [heart_rate.name]}]
     })
-    .then(glucose_device => assert_equals(glucose_device.name, mock_device_name.heart_rate))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    .then(glucose_device => assert_equals(glucose_device.name, mock_device_name.heart_rate));
 }, 'An extra filter doesn\'t prevent matching.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/characteristic/blacklisted-characteristic.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/characteristic/blacklisted-characteristic.html
@@ -16,7 +16,6 @@ promise_test(t => {
     .then(characteristic => {
         return characteristic.readValue()
         .then(() => promise_rejects(t, 'SecurityError', characteristic.writeValue(new Uint8Array(1))));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Characteristic with exclude-writes fullfills read and rejects write.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/characteristic/characteristic-is-removed.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/characteristic/characteristic-is-removed.html
@@ -17,7 +17,6 @@ promise_test(t => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.missing_characteristic_heart_rate);
         return promise_rejects(t, 'InvalidStateError',
                                characteristic.writeValue(new Uint8Array(1)));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Characteristic gets removed. Reject with InvalidStateError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/characteristic/device-goes-out-of-range.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/characteristic/device-goes-out-of-range.html
@@ -16,7 +16,6 @@ promise_test(t => {
     .then(characteristic => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.empty);
         return promise_rejects(t, 'NetworkError', characteristic.writeValue(new Uint8Array(1)));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Device goes out of range. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/characteristic/disconnect-called-before.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/characteristic/disconnect-called-before.html
@@ -18,7 +18,6 @@ promise_test(t => {
             gattServer.disconnect();
             return promise_rejects(t, 'NetworkError', characteristic.writeValue(new Uint8Array(1)));
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before writeValue. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/characteristic/service-is-removed.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/characteristic/service-is-removed.html
@@ -16,7 +16,6 @@ promise_test(t => {
     .then(characteristic => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.missing_service_heart_rate);
         return promise_rejects(t, 'InvalidStateError', characteristic.writeValue(new Uint8Array(1)));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Service gets removed. Reject with InvalidStateError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/characteristic/write-succeeds.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/characteristic/write-succeeds.html
@@ -17,7 +17,6 @@ promise_test(() => {
         characteristic.writeValue(new Uint8Array(1)),
         // characteristic.writeValue(new ArrayBuffer(1)),
         // characteristic.writeValue(new DataView(new ArrayBuffer(1)))
-    ]))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    ]));
 }, 'A regular write request to a writable characteristic should succeed.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/characteristic/write-updates-value.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/characteristic/write-updates-value.html
@@ -17,7 +17,6 @@ promise_test(() => {
         assert_equals(characteristic.value, null);
         return characteristic.writeValue(asciiToDecimal('foo'))
         .then(() => assert_equals(characteristic.value, 'foo'));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'A regular write request to a writable characteristic should update value.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/descriptor/blacklisted-descriptor.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/descriptor/blacklisted-descriptor.html
@@ -18,7 +18,6 @@ promise_test(t => {
     .then(descriptor => {
         return descriptor.readValue()
         .then(() => promise_rejects(t, 'SecurityError', descriptor.writeValue(new Uint8Array(1))));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Descriptor with exclude-writes fullfills read and rejects write.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/descriptor/characteristic-is-removed.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/descriptor/characteristic-is-removed.html
@@ -17,7 +17,6 @@ promise_test(t => {
     .then(descriptor => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.missing_characteristic_heart_rate);
         return promise_rejects(t, 'InvalidStateError', descriptor.writeValue(new Uint8Array(1)));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Characteristic gets removed. Reject with InvalidStateError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/descriptor/descriptor-is-removed.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/descriptor/descriptor-is-removed.html
@@ -17,7 +17,6 @@ promise_test(t => {
     .then(descriptor => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.missing_descriptor_heart_rate);
         return promise_rejects(t, 'InvalidStateError', descriptor.writeValue(new Uint8Array(1)));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Descriptor gets removed. Reject with InvalidStateError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/descriptor/device-goes-out-of-range.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/descriptor/device-goes-out-of-range.html
@@ -17,7 +17,6 @@ promise_test(t => {
     .then(descriptor => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.empty);
         return promise_rejects(t, 'NetworkError', descriptor.writeValue(new Uint8Array(1)));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Device goes out of range. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/descriptor/disconnect-called-before.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/descriptor/disconnect-called-before.html
@@ -19,7 +19,6 @@ promise_test(t => {
             gattServer.disconnect();
             return promise_rejects(t, 'NetworkError', descriptor.writeValue(new Uint8Array(1)));
         });
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'disconnect() called before writeValue. Reject with NetworkError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/descriptor/service-is-removed.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/descriptor/service-is-removed.html
@@ -18,7 +18,6 @@ promise_test(t => {
         window.testRunner.setBluetoothMockDataSet(adapter_type.missing_service_heart_rate);
         return promise_rejects(t, 'InvalidStateError',
                                descriptor.writeValue(new Uint8Array(1)));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'Service gets removed. Reject with InvalidStateError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/descriptor/write-succeeds.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/descriptor/write-succeeds.html
@@ -18,7 +18,6 @@ promise_test(t => {
         descriptor.writeValue(new Uint8Array(1)),
         // characteristic.writeValue(new ArrayBuffer(1)),
         // characteristic.writeValue(new DataView(new ArrayBuffer(1)))
-    ]))
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    ]));
 }, 'A regular write request to a writable descriptor should succeed.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/descriptor/write-updates-value.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/writeValue/descriptor/write-updates-value.html
@@ -18,7 +18,6 @@ promise_test(() => {
         assert_equals(descriptor.value, null);
         return descriptor.writeValue(asciiToDecimal('foo'))
         .then(() => assert_equals(descriptor.value, 'foo'));
-    })
-    .catch(error => assert_unreached('Promise should have resolved. ' + error));
+    });
 }, 'A regular write request to a writable descriptor should update value.');
 </script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Removed empty lines form the `.ini` files, and the catch blocks from the end of the `promies_test` functions.
Made the mentioned changes in the tests (fixing assert messages, replace two for loops with `Promise.all`).
Meanwhile I found the `Promise.all` tests (`getCharacteristics/correct-characteristics.html` and `getDescriptors/correct-descriptors.html`) where wrong, to fix these some modification needed on the servo side as well (first commit).

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
