### PR TITLE
serviceData and manufacturerData filter members

### DIFF
--- a/components/bluetooth_traits/scanfilter.rs
+++ b/components/bluetooth_traits/scanfilter.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::slice::Iter;
 
 // A device name can never be longer than 29 bytes. An adv packet is at most
@@ -23,28 +23,31 @@ impl ServiceUUIDSequence {
     }
 }
 
+type ManufacturerData = HashMap<u16, (Vec<u8>, Vec<u8>)>;
+type ServiceData = HashMap<String, (Vec<u8>, Vec<u8>)>;
+
 #[derive(Deserialize, Serialize)]
 pub struct BluetoothScanfilter {
     name: Option<String>,
     name_prefix: String,
     services: ServiceUUIDSequence,
-    manufacturer_id: Option<u16>,
-    service_data_uuid: String,
+    manufacturer_data: Option<ManufacturerData>,
+    service_data: Option<ServiceData>,
 }
 
 impl BluetoothScanfilter {
     pub fn new(name: Option<String>,
                name_prefix: String,
                services: Vec<String>,
-               manufacturer_id: Option<u16>,
-               service_data_uuid: String)
+               manufacturer_data: Option<ManufacturerData>,
+               service_data: Option<ServiceData>)
                -> BluetoothScanfilter {
         BluetoothScanfilter {
             name: name,
             name_prefix: name_prefix,
             services: ServiceUUIDSequence::new(services),
-            manufacturer_id: manufacturer_id,
-            service_data_uuid: service_data_uuid,
+            manufacturer_data: manufacturer_data,
+            service_data: service_data,
         }
     }
 
@@ -60,20 +63,20 @@ impl BluetoothScanfilter {
         &self.services.0
     }
 
-    pub fn get_manufacturer_id(&self) -> Option<u16> {
-        self.manufacturer_id
+    pub fn get_manufacturer_data(&self) -> &Option<ManufacturerData> {
+        &self.manufacturer_data
     }
 
-    pub fn get_service_data_uuid(&self) -> &str {
-        &self.service_data_uuid
+    pub fn get_service_data(&self) -> &Option<ServiceData> {
+        &self.service_data
     }
 
     pub fn is_empty_or_invalid(&self) -> bool {
         (self.name.is_none() &&
          self.name_prefix.is_empty() &&
          self.get_services().is_empty() &&
-         self.manufacturer_id.is_none() &&
-         self.service_data_uuid.is_empty()) ||
+         self.manufacturer_data.is_none() &&
+         self.service_data.is_none()) ||
         self.get_name().unwrap_or("").len() > MAX_NAME_LENGTH ||
         self.name_prefix.len() > MAX_NAME_LENGTH
     }

--- a/components/script/dom/webidls/Bluetooth.webidl
+++ b/components/script/dom/webidls/Bluetooth.webidl
@@ -4,16 +4,25 @@
 
 // https://webbluetoothcg.github.io/web-bluetooth/#bluetooth
 
-dictionary BluetoothRequestDeviceFilter {
+dictionary BluetoothDataFilterInit {
+//  BufferSource dataPrefix;
+ sequence<octet> dataPrefix;
+//  BufferSource mask;
+  sequence<octet> mask;
+};
+
+dictionary BluetoothLEScanFilterInit {
   sequence<BluetoothServiceUUID> services;
   DOMString name;
   DOMString namePrefix;
-  unsigned short manufacturerId;
-  BluetoothServiceUUID serviceDataUUID;
+//  Maps unsigned shorts to BluetoothDataFilters.
+  MozMap<BluetoothDataFilterInit> manufacturerData;
+//  Maps BluetoothServiceUUIDs to BluetoothDataFilters.
+  MozMap<BluetoothDataFilterInit> serviceData;
 };
 
 dictionary RequestDeviceOptions {
-  sequence<BluetoothRequestDeviceFilter> filters;
+  sequence<BluetoothLEScanFilterInit> filters;
   sequence<BluetoothServiceUUID> optionalServices /*= []*/;
   boolean acceptAllDevices = false;
 };
@@ -23,6 +32,12 @@ interface Bluetooth {
 //  [SecureContext]
 //  readonly attribute BluetoothDevice? referringDevice;
 //  [SecureContext]
+//  Promise<boolean> getAvailability();
+//  [SecureContext]
+//  attribute EventHandler onavailabilitychanged;
+//  [SecureContext]
+//  readonly attribute BluetoothDevice? referringDevice;
+  [SecureContext]
   Promise<BluetoothDevice> requestDevice(optional RequestDeviceOptions options);
 };
 

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -221,12 +221,12 @@ dependencies = [
 
 [[package]]
 name = "blurdroid"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "blurmock"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -553,10 +553,10 @@ dependencies = [
 [[package]]
 name = "device"
 version = "0.0.1"
-source = "git+https://github.com/servo/devices#4a6ab4be0de229fafa6aa3657a5702646832ba08"
+source = "git+https://github.com/servo/devices#1bb5a200c7ae1f42ddf3c42b235b3db66226aabf"
 dependencies = [
- "blurdroid 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "blurmock 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blurdroid 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blurmock 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "blurz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3114,8 +3114,8 @@ dependencies = [
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-"checksum blurdroid 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5fce4ea3366b583e9d49e1aa3a42252e53b42911bccd06f31c3e81c48ccfc79e"
-"checksum blurmock 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c3034c7372bc7951e0a916b7e952b0043cd4ccb5112cd30827f0e1708e05c2b1"
+"checksum blurdroid 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4a86fbb3818e7f850410e026bfac7742fe86cbf4acf49f5752936b32d1f7eb8"
+"checksum blurmock 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "68dd72da3a3bb40f3d3bdd366c4cf8e2b1d208c366304f382c80cef8126ca8da"
 "checksum blurz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d49796c8d5a1b5f6b2b8686e46ed4ab842987c477f765b69f1d3e8df6072608"
 "checksum brotli 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "bff2d5511b5ba5840f46cc3f9c0c3ab09db20e9b9a4db344ef7df3fb547a627a"
 "checksum browserhtml 0.1.17 (git+https://github.com/browserhtml/browserhtml?branch=crate)" = "<none>"

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -191,12 +191,12 @@ dependencies = [
 
 [[package]]
 name = "blurdroid"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "blurmock"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -493,10 +493,10 @@ dependencies = [
 [[package]]
 name = "device"
 version = "0.0.1"
-source = "git+https://github.com/servo/devices#4a6ab4be0de229fafa6aa3657a5702646832ba08"
+source = "git+https://github.com/servo/devices#1bb5a200c7ae1f42ddf3c42b235b3db66226aabf"
 dependencies = [
- "blurdroid 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "blurmock 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blurdroid 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blurmock 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "blurz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2928,8 +2928,8 @@ dependencies = [
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-"checksum blurdroid 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5fce4ea3366b583e9d49e1aa3a42252e53b42911bccd06f31c3e81c48ccfc79e"
-"checksum blurmock 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c3034c7372bc7951e0a916b7e952b0043cd4ccb5112cd30827f0e1708e05c2b1"
+"checksum blurdroid 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4a86fbb3818e7f850410e026bfac7742fe86cbf4acf49f5752936b32d1f7eb8"
+"checksum blurmock 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "68dd72da3a3bb40f3d3bdd366c4cf8e2b1d208c366304f382c80cef8126ca8da"
 "checksum blurz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d49796c8d5a1b5f6b2b8686e46ed4ab842987c477f765b69f1d3e8df6072608"
 "checksum brotli 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "bff2d5511b5ba5840f46cc3f9c0c3ab09db20e9b9a4db344ef7df3fb547a627a"
 "checksum browserhtml 0.1.17 (git+https://github.com/browserhtml/browserhtml?branch=crate)" = "<none>"

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -7364,6 +7364,12 @@
             "url": "/_mozilla/mozilla/bluetooth/requestDevice/blacklisted-service-in-optionalServices.html"
           }
         ],
+        "mozilla/bluetooth/requestDevice/canonicalizeFilter/blocklisted-service-data-key.html": [
+          {
+            "path": "mozilla/bluetooth/requestDevice/canonicalizeFilter/blocklisted-service-data-key.html",
+            "url": "/_mozilla/mozilla/bluetooth/requestDevice/canonicalizeFilter/blocklisted-service-data-key.html"
+          }
+        ],
         "mozilla/bluetooth/requestDevice/canonicalizeFilter/empty-filter.html": [
           {
             "path": "mozilla/bluetooth/requestDevice/canonicalizeFilter/empty-filter.html",
@@ -7460,6 +7466,24 @@
             "url": "/_mozilla/mozilla/bluetooth/requestDevice/canonicalizeFilter/unicode-valid-length-name-namePrefix.html"
           }
         ],
+        "mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-manufacturer-data-key.html": [
+          {
+            "path": "mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-manufacturer-data-key.html",
+            "url": "/_mozilla/mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-manufacturer-data-key.html"
+          }
+        ],
+        "mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-mask-length.html": [
+          {
+            "path": "mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-mask-length.html",
+            "url": "/_mozilla/mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-mask-length.html"
+          }
+        ],
+        "mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-service-data-key.html": [
+          {
+            "path": "mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-service-data-key.html",
+            "url": "/_mozilla/mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-service-data-key.html"
+          }
+        ],
         "mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-service-in-optionalServices-member.html": [
           {
             "path": "mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-service-in-optionalServices-member.html",
@@ -7470,6 +7494,42 @@
           {
             "path": "mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-service-in-services-member.html",
             "url": "/_mozilla/mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-service-in-services-member.html"
+          }
+        ],
+        "mozilla/bluetooth/requestDevice/device-found-using-mask.html": [
+          {
+            "path": "mozilla/bluetooth/requestDevice/device-found-using-mask.html",
+            "url": "/_mozilla/mozilla/bluetooth/requestDevice/device-found-using-mask.html"
+          }
+        ],
+        "mozilla/bluetooth/requestDevice/device-found-with-key-and-value.html": [
+          {
+            "path": "mozilla/bluetooth/requestDevice/device-found-with-key-and-value.html",
+            "url": "/_mozilla/mozilla/bluetooth/requestDevice/device-found-with-key-and-value.html"
+          }
+        ],
+        "mozilla/bluetooth/requestDevice/device-found-with-key-only.html": [
+          {
+            "path": "mozilla/bluetooth/requestDevice/device-found-with-key-only.html",
+            "url": "/_mozilla/mozilla/bluetooth/requestDevice/device-found-with-key-only.html"
+          }
+        ],
+        "mozilla/bluetooth/requestDevice/device-found-with-service-and-manufacturer-data.html": [
+          {
+            "path": "mozilla/bluetooth/requestDevice/device-found-with-service-and-manufacturer-data.html",
+            "url": "/_mozilla/mozilla/bluetooth/requestDevice/device-found-with-service-and-manufacturer-data.html"
+          }
+        ],
+        "mozilla/bluetooth/requestDevice/device-not-found-with-extra-data.html": [
+          {
+            "path": "mozilla/bluetooth/requestDevice/device-not-found-with-extra-data.html",
+            "url": "/_mozilla/mozilla/bluetooth/requestDevice/device-not-found-with-extra-data.html"
+          }
+        ],
+        "mozilla/bluetooth/requestDevice/device-not-found-with-service-and-manufacturer-data.html": [
+          {
+            "path": "mozilla/bluetooth/requestDevice/device-not-found-with-service-and-manufacturer-data.html",
+            "url": "/_mozilla/mozilla/bluetooth/requestDevice/device-not-found-with-service-and-manufacturer-data.html"
           }
         ],
         "mozilla/bluetooth/requestDevice/discovery-succeeds.html": [

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/blocklisted-service-data-key.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/blocklisted-service-data-key.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+let blocklisted_keys = [{
+    filters: [{
+        serviceData: {
+            'heart_rate':                           {},
+            '00001812-0000-1000-8000-00805f9b34fb': {}
+        }
+    }]
+}, {
+    filters: [{
+        serviceData: {
+            'heart_rate':                           {},
+            '00001530-1212-efde-1523-785feabcd123': {}
+        }
+    }]
+}, {
+    filters: [{
+        serviceData: {
+            'heart_rate':                           {},
+            'f000ffc0-0451-4000-b000-000000000000': {}
+        }
+    }]
+}, {
+    filters: [{
+        serviceData: {
+            'heart_rate':             {},
+            'human_interface_device': {}
+        }
+    }]
+}, {
+    filters: [{
+        serviceData: {
+            'heart_rate':  {},
+            0x1812:        {}
+        }
+    }]
+}];
+
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.glucose_heart_rate);
+    let promises = [];
+    blocklisted_keys.forEach(args => {
+        promises.push(promise_rejects(t, 'SecurityError', window.navigator.bluetooth.requestDevice(args)));
+    });
+    return Promise.all(promises);
+}, 'Rejects with SecurityError, if a serviceData key is blocklisted.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-manufacturer-data-key.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-manufacturer-data-key.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<meta charset="utf-8">
+<title></title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+let wrong_manufacturer_data_keys = [{
+    filters: [{
+        manufacturerData: {
+            17:  {},
+            'A': {}
+        }
+    }]
+}, {
+    filters: [{
+        manufacturerData: {
+            17: {},
+            undefined: {}
+        }
+    }]
+}, {
+    filters: [{
+        manufacturerData: {
+            17:   {},
+            null: {}
+        }
+    }]
+}, {
+    filters: [{
+        manufacturerData: {
+            17: {},
+            '': {}
+        }
+    }]
+}, {
+    filters: [{
+        manufacturerData: {
+            17:   {},
+            '-0': {}
+        }
+    }]
+}, {
+    filters: [{
+        manufacturerData: {
+            17:    {},
+            '-17': {}
+        }
+    }]
+}, {
+    filters: [{
+        manufacturerData: {
+            17:    {},
+            65536: {}
+        }
+    }]
+}, {
+    filters: [{
+        manufacturerData: {
+            17:      {},
+            '65536': {}
+        }
+    }]
+}];
+
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.glucose_heart_rate);
+    let promises = [];
+    wrong_manufacturer_data_keys.forEach(args => {
+        promises.push(promise_rejects(t, new TypeError(), window.navigator.bluetooth.requestDevice(args)));
+    });
+    return Promise.all(promises);
+}, 'Rejects with TypeError, if a manufacturerData key is not an unsigned short.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-mask-length.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-mask-length.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+let length_error_cases = [{
+    filters: [{
+        manufacturerData: {
+            17: {
+                dataPrefix: new Uint8Array([0x91, 0xAA, 0x78]),
+                mask: new Uint8Array([0x0F, 0x57])
+            }
+        }
+    }]
+}, {
+    filters: [{
+        manufacturerData: {
+            17: {
+                dataPrefix: new Uint8Array([0x91]),
+                mask: new Uint8Array([0x0F, 0x57])
+            }
+        }
+    }]
+}, {
+    filters: [{
+        manufacturerData: {
+            17: {
+                mask: new Uint8Array([0x0F, 0x57])
+            }
+        }
+    }]
+}, {
+    filters: [{
+        serviceData: {
+            'heart_rate': {
+                dataPrefix: new Uint8Array([0x91, 0xAA, 0x78]),
+                mask: new Uint8Array([0x0F, 0x57])
+            }
+        }
+    }]
+}, {
+    filters: [{
+        serviceData: {
+            'heart_rate': {
+                dataPrefix: new Uint8Array([0x91]),
+                mask: new Uint8Array([0x0F, 0x57])
+            }
+        }
+    }]
+}, {
+    filters: [{
+        serviceData: {
+            'heart_rate': {
+                mask: new Uint8Array([0x0F, 0x57])
+            }
+        }
+    }]
+}];
+
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.glucose_heart_rate);
+    let promises = [];
+    length_error_cases.forEach(args => {
+        promises.push(promise_rejects(t, new TypeError(), window.navigator.bluetooth.requestDevice(args)));
+    });
+    return Promise.all(promises);
+}, 'Rejects with TypeError, if mask present, and does not have the same length as dataPrefix.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-service-data-key.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-service-data-key.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+let wrong_service_data_keys = [{
+    filters: [{
+        serviceData: {
+            'glucose':       {},
+            'wrong_service': {}
+        }
+    }]
+}, {
+    filters: [{
+        serviceData: {
+            'glucose': {},
+            '-240':    {}
+        }
+    }]
+}, {
+    filters: [{
+        serviceData: {
+            'glucose': {},
+            '':        {}
+        }
+    }]
+}, {
+    filters: [{
+        serviceData: {
+            'glucose': {},
+            '-0':      {}
+        }
+    }]
+}, {
+    filters: [{
+        serviceData: {
+            'glucose': {},
+            null:      {}
+        }
+    }]
+}, {
+    filters: [{
+        serviceData: {
+            'glucose': {},
+            undefined: {}
+        }
+    }]
+}, {
+    filters: [{
+        serviceData: {
+            'glucose':    {},
+            '4294967296': {}
+        }
+    }]
+}, {
+    filters: [{
+        serviceData: {
+            'glucose':  {},
+            4294967296: {}
+        }
+    }]
+}, {
+    filters: [{
+        serviceData: {
+            'glucose':                               {},
+            '123456789-0000-1000-8000-00805f9b34fb': {}
+        }
+    }]
+}, {
+    filters: [{
+        serviceData: {
+            'glucose': {},
+            '0x180d':  {}
+        }
+    }]
+}];
+
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.glucose_heart_rate);
+    let promises = [];
+    wrong_service_data_keys.forEach(args => {
+        promises.push(promise_rejects(t, 'SyntaxError', window.navigator.bluetooth.requestDevice(args)));
+    });
+    return Promise.all(promises);
+}, 'Rejects with SyntaxError, if a serviceData key not converts to a valid uuid.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/device-found-using-mask.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/device-found-using-mask.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(() => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.glucose_heart_rate);
+    return Promise.all([
+        window.navigator.bluetooth.requestDevice({
+            filters: [{
+                manufacturerData: {
+                    17: {
+                        dataPrefix: new Uint8Array([0x91, 0xAA, 0x03]),
+                        mask: new Uint8Array([0x0F, 0x57, 0x0F])
+                    }
+                }
+            }]
+        }),
+        window.navigator.bluetooth.requestDevice({
+            filters: [{
+                serviceData: {
+                    0x1808: {
+                        dataPrefix: new Uint8Array([0x91, 0xAA, 0x03]),
+                        mask: new Uint8Array([0x0F, 0x57, 0x0F])
+                    }
+                }
+            }]
+        }),
+        window.navigator.bluetooth.requestDevice({
+            filters: [{
+                manufacturerData: {
+                    17: {
+                        dataPrefix: new Uint8Array([0x91, 0xAA, 0x03]),
+                        mask: new Uint8Array([0x0F, 0x57, 0x0F])
+                    }
+                },
+                serviceData: {
+                    0x1808: {
+                        dataPrefix: new Uint8Array([0x91, 0xAA, 0x03]),
+                        mask: new Uint8Array([0x0F, 0x57, 0x0F])
+                    }
+                }
+            }]
+        }),
+    ])
+    .then(devices => {
+        devices.forEach(device => assert_equals(device.name, mock_device_name.glucose));
+    });
+}, 'A device can be found by requesting service/manufacturerData with a dataPrefix and an appropriate mask');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/device-found-with-key-and-value.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/device-found-with-key-and-value.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(() => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.glucose_heart_rate);
+    return Promise.all([
+        window.navigator.bluetooth.requestDevice({
+            filters: [{
+                manufacturerData: {
+                    17: {dataPrefix: new Uint8Array([1, 2, 3])},
+                }
+            }]
+        }),
+        window.navigator.bluetooth.requestDevice({
+            filters: [{
+                manufacturerData: {
+                    17: {dataPrefix: new Uint8Array([1, 2])},
+                }
+            }]
+        }),
+        window.navigator.bluetooth.requestDevice({
+            filters: [{
+                manufacturerData: {
+                    17: {dataPrefix: new Uint8Array([1])},
+                }
+            }]
+        }),
+        window.navigator.bluetooth.requestDevice({
+            filters: [{
+                serviceData: {
+                    'glucose': {dataPrefix: new Uint8Array([1, 2, 3])},
+                }
+            }]
+        }),
+        window.navigator.bluetooth.requestDevice({
+            filters: [{
+                serviceData: {
+                    '00001808-0000-1000-8000-00805f9b34fb': {dataPrefix: new Uint8Array([1, 2])},
+                }
+            }]
+        }),
+        window.navigator.bluetooth.requestDevice({
+            filters: [{
+                serviceData: {
+                    0x1808: {dataPrefix: new Uint8Array([1])},
+                }
+            }]
+        }),
+        window.navigator.bluetooth.requestDevice({
+            filters: [{
+                manufacturerData: {
+                    17: {dataPrefix: new Uint8Array([1])},
+                },
+                serviceData: {
+                    0x1808: {dataPrefix: new Uint8Array([1])},
+                }
+            }]
+        })
+    ])
+    .then(devices => {
+        devices.forEach(device => assert_equals(device.name, mock_device_name.glucose));
+    });
+}, 'A device can be found by requesting with a service/manufacturerData.dataPrefix, which contains the starting or all bytes of device\'s advertised service/manufacturer specific data bytes.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/device-found-with-key-only.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/device-found-with-key-only.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(() => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.glucose_heart_rate);
+    return Promise.all([
+        window.navigator.bluetooth.requestDevice({
+            filters: [{
+                manufacturerData: {
+                    17: {}
+                }
+            }]
+        }),
+        window.navigator.bluetooth.requestDevice({
+            filters: [{
+                manufacturerData: {
+                    '17': {}
+                }
+            }]
+        }),
+        window.navigator.bluetooth.requestDevice({
+            filters: [{
+                serviceData: {
+                    'glucose': {}
+                }
+            }]
+        }),
+        window.navigator.bluetooth.requestDevice({
+            filters: [{
+                serviceData: {
+                    '00001808-0000-1000-8000-00805f9b34fb': {}
+                }
+            }]
+        }),
+        window.navigator.bluetooth.requestDevice({
+            filters: [{
+                serviceData: {
+                    0x1808: {}
+                }
+            }]
+        })
+    ])
+    .then(devices => {
+        devices.forEach(device => assert_equals(device.name, mock_device_name.glucose));
+    });
+}, 'Only using the correct service/manufacturerData key, a device can be found.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/device-found-with-service-and-manufacturer-data.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/device-found-with-service-and-manufacturer-data.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(() => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.glucose_heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{
+            manufacturerData: {
+                17: {dataPrefix: new Uint8Array([1, 2, 3])},
+            },
+            serviceData: {
+                'glucose': {dataPrefix: new Uint8Array([1, 2, 3])}
+            }
+        }]
+    })
+    .then(device => assert_equals(device.name, mock_device_name.glucose));
+}, 'Requesting with manufacturerData and serviceData in the same filter, will find the device which advertises both.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/device-not-found-with-extra-data.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/device-not-found-with-extra-data.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+let extra_data_filters = [{
+    filters: [{
+        manufacturerData: {
+            17: {},
+            18: {}
+        }
+    }]
+}, {
+    filters: [{
+        serviceData: {
+            'battery_service': {},
+            'glucose': {}
+        }
+    }]
+}, {
+    filters: [{
+        manufacturerData: {
+            17: {},
+            18: {}
+        },
+        serviceData: {
+            'battery_service': {},
+            'glucose': {}
+        }
+    }]
+}, {
+    filters: [{
+        manufacturerData: {
+            17: {}
+        },
+        serviceData: {
+            'battery_service': {},
+            'glucose': {}
+        }
+    }]
+}, {
+    filters: [{
+        manufacturerData: {
+            17: {},
+            18: {}
+        },
+        serviceData: {
+            'glucose': {}
+        }
+    }]
+}];
+
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.glucose_heart_rate);
+    let promises = [];
+    extra_data_filters.forEach(args => {
+        promises.push(promise_rejects(t, 'NotFoundError', window.navigator.bluetooth.requestDevice(args)));
+    });
+    return Promise.all(promises);
+}, 'Requesting with an extra service/manufacturerData, which is not advertised, rejects with NotFoundError.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/device-not-found-with-service-and-manufacturer-data.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/device-not-found-with-service-and-manufacturer-data.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.glucose_heart_rate);
+    return promise_rejects(
+        t, 'NotFoundError',
+        window.navigator.bluetooth.requestDevice({
+            filters: [{
+                manufacturerData: {
+                    17: {dataPrefix: new Uint8Array([1, 2, 3])},
+                },
+                serviceData: {
+                    'heart_rate': {dataPrefix: new Uint8Array([1, 2, 3])}
+                }
+            }]}));
+}, 'Requesting with manufacturerData and serviceData in the same filter, will not find a device which does not advertises both.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/filter-does-not-match.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/filter-does-not-match.html
@@ -11,6 +11,8 @@ let matching_namePrefix = 'Heart';
 let non_matching_services = [battery_service.name];
 let non_matching_name = 'Some Device';
 let non_matching_namePrefix = 'Some';
+let non_matching_manufacturer_data = {18: {}};
+let non_matching_service_data = {'battery_service': {}};
 
 let test_specs = [{
     filters: [{
@@ -80,6 +82,16 @@ let test_specs = [{
 }, {
     filters: [{
         namePrefix: non_matching_namePrefix
+    }]
+}, {
+    filters: [{
+        name: matching_name,
+        manufacturerData: non_matching_manufacturer_data
+    }]
+}, {
+    filters: [{
+        namePrefix: matching_namePrefix,
+        serviceData: non_matching_service_data
     }]
 }];
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Updating `Bluetooth.webidl`. `serviceData` and `manufacturerData` informations can be passed when calling `requestDevice`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
