### PR TITLE
BluetoothUUID wpt tests

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -7238,6 +7238,12 @@
             "url": "/_mozilla/mozilla/bluetooth/getPrimaryServices/services-not-found.html"
           }
         ],
+        "mozilla/bluetooth/idl-BluetoothUUID.html": [
+          {
+            "path": "mozilla/bluetooth/idl-BluetoothUUID.html",
+            "url": "/_mozilla/mozilla/bluetooth/idl-BluetoothUUID.html"
+          }
+        ],
         "mozilla/bluetooth/readValue/characteristic/blacklisted-characteristic.html": [
           {
             "path": "mozilla/bluetooth/readValue/characteristic/blacklisted-characteristic.html",

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/__dir__.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/__dir__.ini
@@ -1,1 +1,1 @@
-prefs: [dom.bluetooth.testing.enabled:true]
+prefs: [dom.bluetooth.enabled:true, dom.bluetooth.testing.enabled:true]

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/bluetooth-helpers.js
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/bluetooth-helpers.js
@@ -1,6 +1,7 @@
 'use strict';
 
 // Bluetooth UUID constants:
+var base_uuid = '00000000-0000-1000-8000-00805f9b34fb'
 // Services:
 var blacklist_test_service_uuid = "611c954a-263b-4f4a-aab6-01ddb953f985";
 var request_disconnection_service_uuid = "01d7d889-7451-419f-aeb8-d65e7b9277af";
@@ -137,6 +138,24 @@ var number_of_digitals = {
     uuid: '00002909-0000-1000-8000-00805f9b34fb'
 };
 
+var alert_notification = {
+    alias: 0x1811,
+    name: 'alert_notification',
+    uuid: '00001811-0000-1000-8000-00805f9b34fb',
+}
+
+var aerobic_heart_rate_lower_limit = {
+    alias: 0x2a7e,
+    name: 'aerobic_heart_rate_lower_limit',
+    uuid: '00002a7e-0000-1000-8000-00805f9b34fb',
+}
+
+var characteristic_extended_properties = {
+    alias: 0x2900,
+    name: 'gatt.characteristic_extended_properties',
+    uuid: '00002900-0000-1000-8000-00805f9b34fb',
+}
+
 // Helper function for converting strings to an array of bytes.
 function asciiToDecimal(bytestr) {
     var result = [];
@@ -145,3 +164,27 @@ function asciiToDecimal(bytestr) {
     }
     return result;
 }
+
+// Variables used to test the BluetoothUUID functions.
+var deadbeef = {
+    alias: 0xDEADBEEF,
+    uuid: 'deadbeef-0000-1000-8000-00805f9b34fb',
+};
+
+var adeadbeef = {
+    alias: 0xADEADBEEF,
+    uuid: 'deadbeef-0000-1000-8000-00805f9b34fb',
+};
+
+var string_alias = 'deadbeef';
+var all_caps_uuid = '1A2B3C4D-5E6F-7A8B-9C0D-1E2F3A4B5C6D';
+var basic_uuid = '1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d';
+var invalid_character_uuid = '0000000g-0000-1000-8000-00805f9b34fb';
+var max_uuid =  'ffffffff-0000-1000-8000-00805f9b34fb';
+var base_alias = 0x0
+var nine_digits =     0xfffffffff;
+var thirteen_digits = 0xfffffffffffff;
+var fourteen_digits = 0xffffffffffffff;
+var array = [];
+var func = () => {};
+var object = {};

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/idl-BluetoothUUID.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/idl-BluetoothUUID.html
@@ -1,0 +1,146 @@
+<!doctype html>
+<meta charset="utf-8">
+<title></title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+
+test(() => {
+  assert_equals(BluetoothUUID.getService(base_alias), base_uuid);
+  assert_equals(BluetoothUUID.getCharacteristic(base_alias), base_uuid);
+  assert_equals(BluetoothUUID.getDescriptor(base_alias), base_uuid);
+}, '0x0 should produce valid UUID.');
+
+test(() => {
+  assert_equals(BluetoothUUID.getService(NaN), base_uuid);
+  assert_equals(BluetoothUUID.getCharacteristic(NaN), base_uuid);
+  assert_equals(BluetoothUUID.getDescriptor(NaN), base_uuid);
+}, 'NaN returns basic uuid');
+
+test(() => {
+  assert_equals(BluetoothUUID.getService(nine_digits), max_uuid);
+  assert_equals(BluetoothUUID.getCharacteristic(nine_digits), max_uuid);
+  assert_equals(BluetoothUUID.getDescriptor(nine_digits), max_uuid);
+  assert_equals(BluetoothUUID.getService(thirteen_digits), max_uuid);
+  assert_equals(BluetoothUUID.getCharacteristic(thirteen_digits), max_uuid);
+  assert_equals(BluetoothUUID.getDescriptor(thirteen_digits), max_uuid);
+  assert_equals(BluetoothUUID.getService(fourteen_digits), base_uuid);
+  assert_equals(BluetoothUUID.getCharacteristic(fourteen_digits), base_uuid);
+  assert_equals(BluetoothUUID.getDescriptor(fourteen_digits), base_uuid);
+}, 'Values between 0xfffffffff (8 digits) and 0xffffffffffffff (14 digits)' +
+   'should return max UUID');
+
+test(() => {
+  assert_equals(BluetoothUUID.getService(Infinity), base_uuid);
+  assert_equals(BluetoothUUID.getCharacteristic(Infinity), base_uuid);
+  assert_equals(BluetoothUUID.getDescriptor(Infinity), base_uuid);
+}, 'Infinity returns base UUID');
+
+test(() => {
+  assert_equals(BluetoothUUID.getService(deadbeef.alias), deadbeef.uuid);
+  assert_equals(BluetoothUUID.getCharacteristic(deadbeef.alias), deadbeef.uuid);
+  assert_equals(BluetoothUUID.getDescriptor(deadbeef.alias), deadbeef.uuid);
+}, '0xdeadbeef should produce valid UUID.');
+
+test(() => {
+  assert_equals(BluetoothUUID.getService(adeadbeef.alias), adeadbeef.uuid);
+  assert_equals(BluetoothUUID.getCharacteristic(adeadbeef.alias), adeadbeef.uuid);
+  assert_equals(BluetoothUUID.getDescriptor(adeadbeef.alias), adeadbeef.uuid);
+}, 'Only first 32bits should be used.');
+
+test(() => {
+  assert_equals(BluetoothUUID.getService(basic_uuid), basic_uuid);
+  assert_equals(BluetoothUUID.getCharacteristic(basic_uuid), basic_uuid);
+  assert_equals(BluetoothUUID.getDescriptor(basic_uuid), basic_uuid);
+}, 'A valid UUID String should return the same UUID.');
+
+test(() => {
+  assert_throws('SyntaxError', () => BluetoothUUID.getService(all_caps_uuid));
+  assert_throws('SyntaxError', () => BluetoothUUID.getCharacteristic(all_caps_uuid));
+  assert_throws('SyntaxError', () => BluetoothUUID.getDescriptor(all_caps_uuid));
+}, 'A UUID String with uppercase letters is an invalid UUID.');
+
+test(() => {
+  assert_throws('SyntaxError', () => BluetoothUUID.getService(string_alias));
+  assert_throws('SyntaxError', () => BluetoothUUID.getCharacteristic(string_alias));
+  assert_throws('SyntaxError', () => BluetoothUUID.getDescriptor(string_alias));
+}, 'A 32bit *String* alias is invalid.');
+
+test(() => {
+  assert_throws('SyntaxError', () => BluetoothUUID.getService(invalid_character_uuid));
+  assert_throws('SyntaxError', () => BluetoothUUID.getCharacteristic(invalid_character_uuid));
+  assert_throws('SyntaxError', () => BluetoothUUID.getDescriptor(invalid_character_uuid));
+}, 'A UUID with invalid characters is an invalid UUID.');
+
+test(() => {
+  assert_equals(BluetoothUUID.getService(alert_notification.name),
+                alert_notification.uuid);
+  assert_equals(BluetoothUUID.getCharacteristic(aerobic_heart_rate_lower_limit.name),
+                aerobic_heart_rate_lower_limit.uuid);
+  assert_equals(BluetoothUUID.getDescriptor(characteristic_extended_properties.name),
+                characteristic_extended_properties.uuid);
+}, 'A valid UUID from a name.');
+
+test(() => {
+  assert_throws('SyntaxError', () => {
+    BluetoothUUID.getService(aerobic_heart_rate_lower_limit.name);
+  });
+  assert_throws('SyntaxError', () => {
+    BluetoothUUID.getService(characteristic_extended_properties.name);
+  });
+  assert_throws('SyntaxError', () => {
+    BluetoothUUID.getCharacteristic(alert_notification.name);
+  });
+  assert_throws('SyntaxError', () => {
+    BluetoothUUID.getCharacteristic(characteristic_extended_properties.name);
+  });
+  assert_throws('SyntaxError', () => {
+    BluetoothUUID.getDescriptor(alert_notification.name);
+  });
+  assert_throws('SyntaxError', () => {
+    BluetoothUUID.getDescriptor(aerobic_heart_rate_lower_limit.name);
+  });
+}, 'Make sure attributes don\'t share a map');
+
+test(() => {
+  assert_throws('SyntaxError', () => BluetoothUUID.getService(wrong.name));
+  assert_throws('SyntaxError', () => BluetoothUUID.getCharacteristic(wrong.name));
+  assert_throws('SyntaxError', () => BluetoothUUID.getDescriptor(wrong.name));
+}, 'Invalid Descriptor name');
+
+test(() => {
+  // cannonicalUUID
+  assert_throws(new TypeError, () => BluetoothUUID.canonicalUUID(object));
+  // [] converts to '', which converts to 0 before the range check.
+  assert_equals(BluetoothUUID.canonicalUUID(array), base_uuid);
+  assert_throws(new TypeError, () => BluetoothUUID.canonicalUUID(func));
+  assert_throws(new TypeError, () => BluetoothUUID.canonicalUUID(undefined));
+  assert_equals(BluetoothUUID.canonicalUUID(null), base_uuid);
+  assert_equals(BluetoothUUID.canonicalUUID(false), base_uuid);
+  assert_equals(BluetoothUUID.canonicalUUID(true), BluetoothUUID.canonicalUUID(1));
+  assert_throws(new TypeError, () => BluetoothUUID.canonicalUUID(NaN));
+  // getService
+  assert_throws('SyntaxError', () => BluetoothUUID.getService(object));
+  assert_throws('SyntaxError', () => BluetoothUUID.getService(array));
+  assert_throws('SyntaxError', () => BluetoothUUID.getService(func));
+  assert_throws('SyntaxError', () => BluetoothUUID.getService(undefined));
+  assert_throws('SyntaxError', () => BluetoothUUID.getService(null));
+  assert_throws('SyntaxError', () => BluetoothUUID.getService(false));
+  // getCharacteristic
+  assert_throws('SyntaxError', () => BluetoothUUID.getCharacteristic(object));
+  assert_throws('SyntaxError', () => BluetoothUUID.getCharacteristic(array));
+  assert_throws('SyntaxError', () => BluetoothUUID.getCharacteristic(func));
+  assert_throws('SyntaxError', () => BluetoothUUID.getCharacteristic(undefined));
+  assert_throws('SyntaxError', () => BluetoothUUID.getCharacteristic(null));
+  assert_throws('SyntaxError', () => BluetoothUUID.getCharacteristic(false));
+  // getDescriptor
+  assert_throws('SyntaxError', () => BluetoothUUID.getDescriptor(object));
+  assert_throws('SyntaxError', () => BluetoothUUID.getDescriptor(array));
+  assert_throws('SyntaxError', () => BluetoothUUID.getDescriptor(func));
+  assert_throws('SyntaxError', () => BluetoothUUID.getDescriptor(undefined));
+  assert_throws('SyntaxError', () => BluetoothUUID.getDescriptor(null));
+  assert_throws('SyntaxError', () => BluetoothUUID.getDescriptor(false));
+}, 'Non-number and non-strings');
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Wpt test for `BluetoothUUID` methods.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes OR

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

