### PR TITLE
Replace SyntaxError with TypeError in BluetoothUUID

### DIFF
--- a/components/script/dom/bluetoothuuid.rs
+++ b/components/script/dom/bluetoothuuid.rs
@@ -267,7 +267,7 @@ const BASE_UUID: &'static str = "-0000-1000-8000-00805f9b34fb";
 const SERVICE_PREFIX: &'static str = "org.bluetooth.service";
 const CHARACTERISTIC_PREFIX: &'static str = "org.bluetooth.characteristic";
 const DESCRIPTOR_PREFIX: &'static str = "org.bluetooth.descriptor";
-const VALID_UUID_REGEX: &'static str = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+const VALID_UUID_REGEX: &'static str = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$";
 // https://cs.chromium.org/chromium/src/third_party/WebKit/Source/modules/bluetooth/BluetoothUUID.cpp?l=314
 const UUID_ERROR_MESSAGE: &'static str = "It must be a valid UUID alias (e.g. 0x1234), \
     UUID (lowercase hex characters e.g. '00001234-0000-1000-8000-00805f9b34fb'),\nor recognized standard name from";

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/invalid-characteristic-name.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/invalid-characteristic-name.html
@@ -12,6 +12,6 @@ promise_test(t => {
     })
     .then(device => device.gatt.connect())
     .then(gattServer => gattServer.getPrimaryService(generic_access.name))
-    .then(service => promise_rejects(t, 'SyntaxError', service.getCharacteristic(wrong.name)));
-}, 'Wrong Characteristic name. Reject with SyntaxError.');
+    .then(service => promise_rejects(t, new TypeError(), service.getCharacteristic(wrong.name)));
+}, 'Wrong Characteristic name. Reject with TypeError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/invalid-characteristic-name.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/invalid-characteristic-name.html
@@ -12,6 +12,6 @@ promise_test(t => {
     })
     .then(device => device.gatt.connect())
     .then(gattServer => gattServer.getPrimaryService(generic_access.name))
-    .then(service => promise_rejects(t, 'SyntaxError', service.getCharacteristics(wrong.name)));
-}, 'Invalid Characteristic name. Reject with SyntaxError.');
+    .then(service => promise_rejects(t, new TypeError(), service.getCharacteristics(wrong.name)));
+}, 'Invalid Characteristic name. Reject with TypeError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/invalid-descriptor-name.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/invalid-descriptor-name.html
@@ -13,6 +13,6 @@ promise_test(t => {
     .then(device => device.gatt.connect())
     .then(gattServer => gattServer.getPrimaryService(generic_access.name))
     .then(service => service.getCharacteristic(device_name.name))
-    .then(characteristic => promise_rejects(t, 'SyntaxError', characteristic.getDescriptor(wrong.name)));
-}, 'Wrong descriptor name. Reject with SyntaxError.');
+    .then(characteristic => promise_rejects(t, new TypeError(), characteristic.getDescriptor(wrong.name)));
+}, 'Wrong descriptor name. Reject with TypeError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/invalid-descriptor-name.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/invalid-descriptor-name.html
@@ -13,6 +13,6 @@ promise_test(t => {
     .then(device => device.gatt.connect())
     .then(gattServer => gattServer.getPrimaryService(generic_access.name))
     .then(service => service.getCharacteristic(device_name.name))
-    .then(characteristic => promise_rejects(t, 'SyntaxError', characteristic.getDescriptors(wrong.name)));
-}, 'Wrong descriptor name. Reject with SyntaxError.');
+    .then(characteristic => promise_rejects(t, new TypeError(), characteristic.getDescriptors(wrong.name)));
+}, 'Wrong descriptor name. Reject with TypeError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/invalid-service-name.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/invalid-service-name.html
@@ -10,6 +10,6 @@ promise_test(t => {
         filters: [{services: [heart_rate.name]}]
     })
     .then(device => device.gatt.connect())
-    .then(gattServer => promise_rejects(t, 'SyntaxError', gattServer.getPrimaryService(wrong.name)));
-}, 'Wrong Service name. Reject with SyntaxError.');
+    .then(gattServer => promise_rejects(t, new TypeError(), gattServer.getPrimaryService(wrong.name)));
+}, 'Wrong Service name. Reject with TypeError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/invalid-service-name.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/invalid-service-name.html
@@ -10,6 +10,6 @@ promise_test(t => {
         filters: [{services: [heart_rate.name]}]
     })
     .then(device => device.gatt.connect())
-    .then(gattServer => promise_rejects(t, 'SyntaxError', gattServer.getPrimaryServices(wrong.name)));
-}, 'Wrong Service name. Reject with SyntaxError.');
+    .then(gattServer => promise_rejects(t, new TypeError(), gattServer.getPrimaryServices(wrong.name)));
+}, 'Wrong Service name. Reject with TypeError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/idl-BluetoothUUID.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/idl-BluetoothUUID.html
@@ -83,23 +83,23 @@ test(() => {
 
 test(() => {
   let all_caps_uuid = '1A2B3C4D-5E6F-7A8B-9C0D-1E2F3A4B5C6D';
-  assert_throws('SyntaxError', () => BluetoothUUID.getService(all_caps_uuid));
-  assert_throws('SyntaxError', () => BluetoothUUID.getCharacteristic(all_caps_uuid));
-  assert_throws('SyntaxError', () => BluetoothUUID.getDescriptor(all_caps_uuid));
+  assert_throws(new TypeError(), () => BluetoothUUID.getService(all_caps_uuid));
+  assert_throws(new TypeError(), () => BluetoothUUID.getCharacteristic(all_caps_uuid));
+  assert_throws(new TypeError(), () => BluetoothUUID.getDescriptor(all_caps_uuid));
 }, 'A UUID String with uppercase letters is an invalid UUID.');
 
 test(() => {
   let string_alias = 'deadbeef';
-  assert_throws('SyntaxError', () => BluetoothUUID.getService(string_alias));
-  assert_throws('SyntaxError', () => BluetoothUUID.getCharacteristic(string_alias));
-  assert_throws('SyntaxError', () => BluetoothUUID.getDescriptor(string_alias));
+  assert_throws(new TypeError(), () => BluetoothUUID.getService(string_alias));
+  assert_throws(new TypeError(), () => BluetoothUUID.getCharacteristic(string_alias));
+  assert_throws(new TypeError(), () => BluetoothUUID.getDescriptor(string_alias));
 }, 'A 32bit *String* alias is invalid.');
 
 test(() => {
   let invalid_character_uuid = '0000000g-0000-1000-8000-00805f9b34fb';
-  assert_throws('SyntaxError', () => BluetoothUUID.getService(invalid_character_uuid));
-  assert_throws('SyntaxError', () => BluetoothUUID.getCharacteristic(invalid_character_uuid));
-  assert_throws('SyntaxError', () => BluetoothUUID.getDescriptor(invalid_character_uuid));
+  assert_throws(new TypeError(), () => BluetoothUUID.getService(invalid_character_uuid));
+  assert_throws(new TypeError(), () => BluetoothUUID.getCharacteristic(invalid_character_uuid));
+  assert_throws(new TypeError(), () => BluetoothUUID.getDescriptor(invalid_character_uuid));
 }, 'A UUID with invalid characters is an invalid UUID.');
 
 test(() => {
@@ -112,31 +112,31 @@ test(() => {
 }, 'A valid UUID from a name.');
 
 test(() => {
-  assert_throws('SyntaxError', () => {
+  assert_throws(new TypeError(), () => {
     BluetoothUUID.getService(aerobic_heart_rate_lower_limit.name);
   });
-  assert_throws('SyntaxError', () => {
+  assert_throws(new TypeError(), () => {
     BluetoothUUID.getService(characteristic_extended_properties.name);
   });
-  assert_throws('SyntaxError', () => {
+  assert_throws(new TypeError(), () => {
     BluetoothUUID.getCharacteristic(alert_notification.name);
   });
-  assert_throws('SyntaxError', () => {
+  assert_throws(new TypeError(), () => {
     BluetoothUUID.getCharacteristic(characteristic_extended_properties.name);
   });
-  assert_throws('SyntaxError', () => {
+  assert_throws(new TypeError(), () => {
     BluetoothUUID.getDescriptor(alert_notification.name);
   });
-  assert_throws('SyntaxError', () => {
+  assert_throws(new TypeError(), () => {
     BluetoothUUID.getDescriptor(aerobic_heart_rate_lower_limit.name);
   });
 }, 'Make sure attributes don\'t share a map');
 
 test(() => {
   let wrong_name = 'wrong_name';
-  assert_throws('SyntaxError', () => BluetoothUUID.getService(wrong_name));
-  assert_throws('SyntaxError', () => BluetoothUUID.getCharacteristic(wrong_name));
-  assert_throws('SyntaxError', () => BluetoothUUID.getDescriptor(wrong_name));
+  assert_throws(new TypeError(), () => BluetoothUUID.getService(wrong_name));
+  assert_throws(new TypeError(), () => BluetoothUUID.getCharacteristic(wrong_name));
+  assert_throws(new TypeError(), () => BluetoothUUID.getDescriptor(wrong_name));
 }, 'Invalid Descriptor name');
 
 test(() => {
@@ -154,25 +154,25 @@ test(() => {
   assert_equals(BluetoothUUID.canonicalUUID(true), BluetoothUUID.canonicalUUID(1));
   assert_throws(new TypeError, () => BluetoothUUID.canonicalUUID(NaN));
   // getService
-  assert_throws('SyntaxError', () => BluetoothUUID.getService(object));
-  assert_throws('SyntaxError', () => BluetoothUUID.getService(array));
-  assert_throws('SyntaxError', () => BluetoothUUID.getService(func));
-  assert_throws('SyntaxError', () => BluetoothUUID.getService(undefined));
-  assert_throws('SyntaxError', () => BluetoothUUID.getService(null));
-  assert_throws('SyntaxError', () => BluetoothUUID.getService(false));
+  assert_throws(new TypeError(), () => BluetoothUUID.getService(object));
+  assert_throws(new TypeError(), () => BluetoothUUID.getService(array));
+  assert_throws(new TypeError(), () => BluetoothUUID.getService(func));
+  assert_throws(new TypeError(), () => BluetoothUUID.getService(undefined));
+  assert_throws(new TypeError(), () => BluetoothUUID.getService(null));
+  assert_throws(new TypeError(), () => BluetoothUUID.getService(false));
   // getCharacteristic
-  assert_throws('SyntaxError', () => BluetoothUUID.getCharacteristic(object));
-  assert_throws('SyntaxError', () => BluetoothUUID.getCharacteristic(array));
-  assert_throws('SyntaxError', () => BluetoothUUID.getCharacteristic(func));
-  assert_throws('SyntaxError', () => BluetoothUUID.getCharacteristic(undefined));
-  assert_throws('SyntaxError', () => BluetoothUUID.getCharacteristic(null));
-  assert_throws('SyntaxError', () => BluetoothUUID.getCharacteristic(false));
+  assert_throws(new TypeError(), () => BluetoothUUID.getCharacteristic(object));
+  assert_throws(new TypeError(), () => BluetoothUUID.getCharacteristic(array));
+  assert_throws(new TypeError(), () => BluetoothUUID.getCharacteristic(func));
+  assert_throws(new TypeError(), () => BluetoothUUID.getCharacteristic(undefined));
+  assert_throws(new TypeError(), () => BluetoothUUID.getCharacteristic(null));
+  assert_throws(new TypeError(), () => BluetoothUUID.getCharacteristic(false));
   // getDescriptor
-  assert_throws('SyntaxError', () => BluetoothUUID.getDescriptor(object));
-  assert_throws('SyntaxError', () => BluetoothUUID.getDescriptor(array));
-  assert_throws('SyntaxError', () => BluetoothUUID.getDescriptor(func));
-  assert_throws('SyntaxError', () => BluetoothUUID.getDescriptor(undefined));
-  assert_throws('SyntaxError', () => BluetoothUUID.getDescriptor(null));
-  assert_throws('SyntaxError', () => BluetoothUUID.getDescriptor(false));
+  assert_throws(new TypeError(), () => BluetoothUUID.getDescriptor(object));
+  assert_throws(new TypeError(), () => BluetoothUUID.getDescriptor(array));
+  assert_throws(new TypeError(), () => BluetoothUUID.getDescriptor(func));
+  assert_throws(new TypeError(), () => BluetoothUUID.getDescriptor(undefined));
+  assert_throws(new TypeError(), () => BluetoothUUID.getDescriptor(null));
+  assert_throws(new TypeError(), () => BluetoothUUID.getDescriptor(false));
 }, 'Non-number and non-strings');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-service-data-key.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-service-data-key.html
@@ -81,8 +81,8 @@ promise_test(t => {
     window.testRunner.setBluetoothMockDataSet(adapter_type.glucose_heart_rate);
     let promises = [];
     wrong_service_data_keys.forEach(args => {
-        promises.push(promise_rejects(t, 'SyntaxError', window.navigator.bluetooth.requestDevice(args)));
+        promises.push(promise_rejects(t, new TypeError(), window.navigator.bluetooth.requestDevice(args)));
     });
     return Promise.all(promises);
-}, 'Rejects with SyntaxError, if a serviceData key does not convert to a valid uuid.');
+}, 'Rejects with TypeError, if a serviceData key does not convert to a valid uuid.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-service-in-optionalServices-member.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-service-in-optionalServices-member.html
@@ -31,7 +31,7 @@ promise_test(t => {
     window.testRunner.setBluetoothMockDataSet(adapter_type.empty);
     let promises = [];
     test_specs.forEach(args => {
-        promises.push(promise_rejects(t, 'SyntaxError', window.navigator.bluetooth.requestDevice(args)));
+        promises.push(promise_rejects(t, new TypeError(), window.navigator.bluetooth.requestDevice(args)));
     });
     return Promise.all(promises);
 }, 'Invalid optional service must reject the promise.');

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-service-in-services-member.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/requestDevice/canonicalizeFilter/wrong-service-in-services-member.html
@@ -30,7 +30,7 @@ promise_test(t => {
     window.testRunner.setBluetoothMockDataSet(adapter_type.empty);
     let promises = [];
     test_specs.forEach(args => {
-        promises.push(promise_rejects(t, 'SyntaxError', window.navigator.bluetooth.requestDevice(args)));
+        promises.push(promise_rejects(t, new TypeError(), window.navigator.bluetooth.requestDevice(args)));
     });
     return Promise.all(promises);
 }, 'Invalid optional service must reject the promise.');


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Replacing the returned SyntaxError with TypeErrors in BluetoothUUID. 
The message Strings are form the [chrome implementation](https://cs.chromium.org/chromium/src/third_party/WebKit/Source/modules/bluetooth/BluetoothUUID.cpp?sq=package:chromium&dr=CSs&l=308).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

