### PR TITLE
Moved the AttributeInstanceMaps from bluetooth to bluetoothDevice.

### DIFF
--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -21,9 +21,6 @@ use dom::bindings::reflector::{Reflectable, reflect_dom_object};
 use dom::bindings::str::DOMString;
 use dom::bluetoothadvertisingdata::BluetoothAdvertisingData;
 use dom::bluetoothdevice::BluetoothDevice;
-use dom::bluetoothremotegattcharacteristic::BluetoothRemoteGATTCharacteristic;
-use dom::bluetoothremotegattdescriptor::BluetoothRemoteGATTDescriptor;
-use dom::bluetoothremotegattservice::BluetoothRemoteGATTService;
 use dom::bluetoothuuid::{BluetoothServiceUUID, BluetoothUUID};
 use dom::eventtarget::EventTarget;
 use dom::globalscope::GlobalScope;
@@ -90,9 +87,6 @@ impl<Listener: AsyncBluetoothListener + Reflectable> BluetoothResponseListener f
 pub struct Bluetooth {
     eventtarget: EventTarget,
     device_instance_map: DOMRefCell<HashMap<String, MutHeap<JS<BluetoothDevice>>>>,
-    service_instance_map: DOMRefCell<HashMap<String, MutHeap<JS<BluetoothRemoteGATTService>>>>,
-    characteristic_instance_map: DOMRefCell<HashMap<String, MutHeap<JS<BluetoothRemoteGATTCharacteristic>>>>,
-    descriptor_instance_map: DOMRefCell<HashMap<String, MutHeap<JS<BluetoothRemoteGATTDescriptor>>>>,
 }
 
 impl Bluetooth {
@@ -100,9 +94,6 @@ impl Bluetooth {
         Bluetooth {
             eventtarget: EventTarget::new_inherited(),
             device_instance_map: DOMRefCell::new(HashMap::new()),
-            service_instance_map: DOMRefCell::new(HashMap::new()),
-            characteristic_instance_map: DOMRefCell::new(HashMap::new()),
-            descriptor_instance_map: DOMRefCell::new(HashMap::new()),
         }
     }
 
@@ -110,19 +101,6 @@ impl Bluetooth {
         reflect_dom_object(box Bluetooth::new_inherited(),
                            global,
                            BluetoothBinding::Wrap)
-    }
-
-    pub fn get_service_map(&self) -> &DOMRefCell<HashMap<String, MutHeap<JS<BluetoothRemoteGATTService>>>> {
-        &self.service_instance_map
-    }
-
-    pub fn get_characteristic_map(&self)
-            -> &DOMRefCell<HashMap<String, MutHeap<JS<BluetoothRemoteGATTCharacteristic>>>> {
-        &self.characteristic_instance_map
-    }
-
-    pub fn get_descriptor_map(&self) -> &DOMRefCell<HashMap<String, MutHeap<JS<BluetoothRemoteGATTDescriptor>>>> {
-        &self.descriptor_instance_map
     }
 
     fn get_bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {

--- a/components/script/dom/bluetoothdevice.rs
+++ b/components/script/dom/bluetoothdevice.rs
@@ -2,17 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use bluetooth_traits::{BluetoothCharacteristicMsg, BluetoothDescriptorMsg, BluetoothServiceMsg};
+use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::BluetoothDeviceBinding;
 use dom::bindings::codegen::Bindings::BluetoothDeviceBinding::BluetoothDeviceMethods;
+use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerMethods;
 use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
 use dom::bindings::js::{JS, Root, MutHeap, MutNullableHeap};
 use dom::bindings::reflector::{Reflectable, reflect_dom_object};
 use dom::bindings::str::DOMString;
 use dom::bluetooth::Bluetooth;
 use dom::bluetoothadvertisingdata::BluetoothAdvertisingData;
+use dom::bluetoothcharacteristicproperties::BluetoothCharacteristicProperties;
+use dom::bluetoothremotegattcharacteristic::BluetoothRemoteGATTCharacteristic;
+use dom::bluetoothremotegattdescriptor::BluetoothRemoteGATTDescriptor;
 use dom::bluetoothremotegattserver::BluetoothRemoteGATTServer;
+use dom::bluetoothremotegattservice::BluetoothRemoteGATTService;
 use dom::eventtarget::EventTarget;
 use dom::globalscope::GlobalScope;
+use std::collections::HashMap;
+
 
 // https://webbluetoothcg.github.io/web-bluetooth/#bluetoothdevice
 #[dom_struct]
@@ -23,6 +32,9 @@ pub struct BluetoothDevice {
     ad_data: MutHeap<JS<BluetoothAdvertisingData>>,
     gatt: MutNullableHeap<JS<BluetoothRemoteGATTServer>>,
     context: MutHeap<JS<Bluetooth>>,
+    attribute_instance_map: (DOMRefCell<HashMap<String, MutHeap<JS<BluetoothRemoteGATTService>>>>,
+                             DOMRefCell<HashMap<String, MutHeap<JS<BluetoothRemoteGATTCharacteristic>>>>,
+                             DOMRefCell<HashMap<String, MutHeap<JS<BluetoothRemoteGATTDescriptor>>>>),
 }
 
 impl BluetoothDevice {
@@ -38,6 +50,9 @@ impl BluetoothDevice {
             ad_data: MutHeap::new(ad_data),
             gatt: Default::default(),
             context: MutHeap::new(context),
+            attribute_instance_map: (DOMRefCell::new(HashMap::new()),
+                                     DOMRefCell::new(HashMap::new()),
+                                     DOMRefCell::new(HashMap::new())),
         }
     }
 
@@ -57,6 +72,70 @@ impl BluetoothDevice {
 
     pub fn get_context(&self) -> Root<Bluetooth> {
         self.context.get()
+    }
+
+    pub fn get_or_create_service(&self,
+                                 service: &BluetoothServiceMsg,
+                                 server: &BluetoothRemoteGATTServer)
+                                 -> Root<BluetoothRemoteGATTService> {
+        let (ref service_map_ref, _, _) = self.attribute_instance_map;
+        let mut service_map = service_map_ref.borrow_mut();
+        if let Some(existing_service) = service_map.get(&service.instance_id) {
+            return existing_service.get();
+        }
+        let bt_service = BluetoothRemoteGATTService::new(&server.global(),
+                                                         &server.Device(),
+                                                         DOMString::from(service.uuid.clone()),
+                                                         service.is_primary,
+                                                         service.instance_id.clone());
+        service_map.insert(service.instance_id.clone(), MutHeap::new(&bt_service));
+        return bt_service;
+    }
+
+    pub fn get_or_create_characteristic(&self,
+                                        characteristic: &BluetoothCharacteristicMsg,
+                                        service: &BluetoothRemoteGATTService)
+                                        -> Root<BluetoothRemoteGATTCharacteristic> {
+        let (_, ref characteristic_map_ref, _) = self.attribute_instance_map;
+        let mut characteristic_map = characteristic_map_ref.borrow_mut();
+        if let Some(existing_characteristic) = characteristic_map.get(&characteristic.instance_id) {
+            return existing_characteristic.get();
+        }
+        let properties =
+            BluetoothCharacteristicProperties::new(&service.global(),
+                                                   characteristic.broadcast,
+                                                   characteristic.read,
+                                                   characteristic.write_without_response,
+                                                   characteristic.write,
+                                                   characteristic.notify,
+                                                   characteristic.indicate,
+                                                   characteristic.authenticated_signed_writes,
+                                                   characteristic.reliable_write,
+                                                   characteristic.writable_auxiliaries);
+        let bt_characteristic = BluetoothRemoteGATTCharacteristic::new(&service.global(),
+                                                                       service,
+                                                                       DOMString::from(characteristic.uuid.clone()),
+                                                                       &properties,
+                                                                       characteristic.instance_id.clone());
+        characteristic_map.insert(characteristic.instance_id.clone(), MutHeap::new(&bt_characteristic));
+        return bt_characteristic;
+    }
+
+    pub fn get_or_create_descriptor(&self,
+                                    descriptor: &BluetoothDescriptorMsg,
+                                    characteristic: &BluetoothRemoteGATTCharacteristic)
+                                    -> Root<BluetoothRemoteGATTDescriptor> {
+        let (_, _, ref descriptor_map_ref) = self.attribute_instance_map;
+        let mut descriptor_map = descriptor_map_ref.borrow_mut();
+        if let Some(existing_descriptor) = descriptor_map.get(&descriptor.instance_id) {
+            return existing_descriptor.get();
+        }
+        let bt_descriptor = BluetoothRemoteGATTDescriptor::new(&characteristic.global(),
+                                                               characteristic,
+                                                               DOMString::from(descriptor.uuid.clone()),
+                                                               descriptor.instance_id.clone());
+        descriptor_map.insert(descriptor.instance_id.clone(), MutHeap::new(&bt_descriptor));
+        return bt_descriptor;
     }
 }
 

--- a/components/script/dom/bluetoothdevice.rs
+++ b/components/script/dom/bluetoothdevice.rs
@@ -70,10 +70,6 @@ impl BluetoothDevice {
                            BluetoothDeviceBinding::Wrap)
     }
 
-    pub fn get_context(&self) -> Root<Bluetooth> {
-        self.context.get()
-    }
-
     pub fn get_or_create_service(&self,
                                  service: &BluetoothServiceMsg,
                                  server: &BluetoothRemoteGATTServer)

--- a/components/script/dom/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetoothremotegattserver.rs
@@ -11,10 +11,8 @@ use dom::bindings::error::Error::{self, Network, Security};
 use dom::bindings::error::ErrorResult;
 use dom::bindings::js::{JS, MutHeap, Root};
 use dom::bindings::reflector::{Reflectable, Reflector, reflect_dom_object};
-use dom::bindings::str::DOMString;
 use dom::bluetooth::{AsyncBluetoothListener, response_async};
 use dom::bluetoothdevice::BluetoothDevice;
-use dom::bluetoothremotegattservice::BluetoothRemoteGATTService;
 use dom::bluetoothuuid::{BluetoothServiceUUID, BluetoothUUID};
 use dom::globalscope::GlobalScope;
 use dom::promise::Promise;
@@ -197,6 +195,7 @@ impl BluetoothRemoteGATTServerMethods for BluetoothRemoteGATTServer {
 
 impl AsyncBluetoothListener for BluetoothRemoteGATTServer {
     fn handle_response(&self, response: BluetoothResponse, promise_cx: *mut JSContext, promise: &Rc<Promise>) {
+        let device = self.Device();
         match response {
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-connect
             BluetoothResponse::GATTServerConnect(connected) => {
@@ -210,17 +209,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTServer {
             // https://webbluetoothcg.github.io/web-bluetooth/#getgattchildren
             // Step 7.
             BluetoothResponse::GetPrimaryService(service) => {
-                let context = self.device.get().get_context();
-                let mut service_map = context.get_service_map().borrow_mut();
-                if let Some(existing_service) = service_map.get(&service.instance_id) {
-                    promise.resolve_native(promise_cx, &existing_service.get());
-                }
-                let bt_service = BluetoothRemoteGATTService::new(&self.global(),
-                                                                 &self.device.get(),
-                                                                 DOMString::from(service.uuid),
-                                                                 service.is_primary,
-                                                                 service.instance_id.clone());
-                service_map.insert(service.instance_id, MutHeap::new(&bt_service));
+                let bt_service = device.get_or_create_service(&service, &self);
                 promise.resolve_native(promise_cx, &bt_service);
             },
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-getprimaryservices
@@ -228,22 +217,8 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTServer {
             // Step 7.
             BluetoothResponse::GetPrimaryServices(services_vec) => {
                 let mut services = vec!();
-                let context = self.device.get().get_context();
-                let mut service_map = context.get_service_map().borrow_mut();
                 for service in services_vec {
-                    let bt_service = match service_map.get(&service.instance_id) {
-                        Some(existing_service) => existing_service.get(),
-                        None => {
-                            BluetoothRemoteGATTService::new(&self.global(),
-                                                            &self.device.get(),
-                                                            DOMString::from(service.uuid),
-                                                            service.is_primary,
-                                                            service.instance_id.clone())
-                        },
-                    };
-                    if !service_map.contains_key(&service.instance_id) {
-                        service_map.insert(service.instance_id, MutHeap::new(&bt_service));
-                    }
+                    let bt_service = device.get_or_create_service(&service, &self);
                     services.push(bt_service);
                 }
                 promise.resolve_native(promise_cx, &services);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Moved the three attribute instance maps (service, characteristic, descriptor) from bluetooth.rs into bluetoothdevice.rs (as a tuple).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

