### PR TITLE
Update the checks for cached ids in bluetooth/lib.rs

### DIFF
--- a/components/script/dom/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetoothremotegattcharacteristic.rs
@@ -128,9 +128,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
             return p;
         }
 
-        // TODO: Step 5: Implement representedService internal slot for BluetoothRemoteGATTService.
-
-        // Note: Steps 6 - 7 are implemented in components/bluetooth/lib.rs in get_descriptor function
+        // Note: Steps 5 - 7 are implemented in components/bluetooth/lib.rs in get_descriptor function
         // and in handle_response function.
         let sender = response_async(&p, self);
         self.get_bluetooth_thread().send(
@@ -171,9 +169,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
             return p;
         }
 
-        // TODO: Step 5: Implement representedService internal slot for BluetoothRemoteGATTService.
-
-        // Note: Steps 6 - 7 are implemented in components/bluetooth/lib.rs in get_descriptors function
+        // Note: Steps 5 - 7 are implemented in components/bluetooth/lib.rs in get_descriptors function
         // and in handle_response function.
         let sender = response_async(&p, self);
         self.get_bluetooth_thread().send(
@@ -204,8 +200,6 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
             return p;
         }
 
-        // TODO: Step 3 - 4: Implement representedCharacteristic internal slot for BluetoothRemoteGATTCharacteristic.
-
         // TODO: Step 5: Implement the `connection-checking-wrapper` algorithm for BluetoothRemoteGATTServer.
 
         // Step 5.1.
@@ -214,8 +208,8 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
             return p;
         }
 
-        // Note: Remaining substeps of Step 5 are implemented in components/bluetooth/lib.rs in readValue function
-        // and in handle_response function.
+        // Note: Steps 3 - 4 and the remaining substeps of Step 5 are implemented in components/bluetooth/lib.rs
+        // in readValue function and in handle_response function.
         let sender = response_async(&p, self);
         self.get_bluetooth_thread().send(
             BluetoothRequest::ReadValue(self.get_instance_id(), sender)).unwrap();
@@ -246,8 +240,6 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
             return p;
         }
 
-        // TODO: Step 5 - 6: Implement representedCharacteristic internal slot for BluetoothRemoteGATTCharacteristic.
-
         // TODO: Step 7: Implement the `connection-checking-wrapper` algorithm for BluetoothRemoteGATTServer.
 
         // Step 7.1.
@@ -258,8 +250,8 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
             return p;
         }
 
-        // Note: Remaining substeps of Step 7 are implemented in components/bluetooth/lib.rs in writeValue function
-        // and in handle_response function.
+        // Note: Steps 5 - 6 and the remaining substeps of Step 7 are implemented in components/bluetooth/lib.rs
+        // in writeValue function and in handle_response function.
         let sender = response_async(&p, self);
         self.get_bluetooth_thread().send(
             BluetoothRequest::WriteValue(self.get_instance_id(), value, sender)).unwrap();
@@ -278,8 +270,6 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
             return p;
         }
 
-        // TODO: Step 2 - 3: Implement representedCharacteristic internal slot for BluetoothRemoteGATTCharacteristic.
-
         // Step 4.
         if !(self.Properties().Notify() ||
              self.Properties().Indicate()) {
@@ -295,7 +285,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
             return p;
         }
 
-        // Note: Steps 7 - 11 are implemented in components/bluetooth/lib.rs in enable_notification function
+        // Note: Steps 2 - 3, 7 - 11 are implemented in components/bluetooth/lib.rs in enable_notification function
         // and in handle_response function.
         let sender = response_async(&p, self);
         self.get_bluetooth_thread().send(
@@ -311,11 +301,10 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
         let p = Promise::new(&self.global());
         let sender = response_async(&p, self);
 
-        // TODO: Step 1 - 4: Implement representedCharacteristic internal slot and
-        // `active notification context set` for BluetoothRemoteGATTCharacteristic,
+        // TODO: Step 3 - 4: Implement `active notification context set` for BluetoothRemoteGATTCharacteristic,
 
-        // Note: Part of Step 4 and Step 5 are implemented in components/bluetooth/lib.rs in enable_notification
-        // function and in handle_response function.
+        // Note: Steps 1 - 2, and part of Step 4 and Step 5 are implemented in components/bluetooth/lib.rs
+        // in enable_notification function and in handle_response function.
         self.get_bluetooth_thread().send(
             BluetoothRequest::EnableNotification(self.get_instance_id(),
                                                  false,

--- a/components/script/dom/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetoothremotegattdescriptor.rs
@@ -103,11 +103,9 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
             return p;
         }
 
-        // TODO: Step 3 - 4: Implement representedDescriptor internal slot for BluetoothRemoteGATTDescriptor.
-
         // TODO: Step 5: Implement the `connection-checking-wrapper` algorithm for BluetoothRemoteGATTServer.
-        // Note: Substeps of Step 5 are implemented in components/bluetooth/lib.rs in readValue function
-        // and in handle_response function.
+        // Note: Steps 3 - 4 and substeps of Step 5 are implemented in components/bluetooth/lib.rs
+        // in readValue function and in handle_response function.
         let sender = response_async(&p, self);
         self.get_bluetooth_thread().send(
             BluetoothRequest::ReadValue(self.get_instance_id(), sender)).unwrap();
@@ -138,11 +136,9 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
             return p;
         }
 
-        // TODO: Step 5 - 6: Implement representedCharacteristic internal slot for BluetoothRemoteGATTCharacteristic.
-
         // TODO: Step 7: Implement the `connection-checking-wrapper` algorithm for BluetoothRemoteGATTServer.
-        // Note: Substeps of Step 7 are implemented in components/bluetooth/lib.rs in writeValue function
-        // and in handle_response function.
+        // Note: Steps 5 - 6 and substeps of Step 7 are implemented in components/bluetooth/lib.rs
+        // in writeValue function and in handle_response function.
         let sender = response_async(&p, self);
         self.get_bluetooth_thread().send(
             BluetoothRequest::WriteValue(self.get_instance_id(), value, sender)).unwrap();

--- a/components/script/dom/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetoothremotegattserver.rs
@@ -67,17 +67,14 @@ impl BluetoothRemoteGATTServerMethods for BluetoothRemoteGATTServer {
         let p = Promise::new(&self.global());
         let sender = response_async(&p, self);
 
-        // TODO: Step 2: Implement representedDevice internal slot for BluetoothDevice.
-
         // TODO: Step 3: Check if the UA is currently using the Bluetooth system.
 
         // TODO: Step 4: Implement activeAlgorithms internal slot for BluetoothRemoteGATTServer.
 
-        // TODO: Step 5.1 - 5.2: Implement activeAlgorithms, representedDevice internal slots
-        // and the` garbage-collect the connection` algorithm.
+        // TODO: Step 5.1 - 5.2: Implement activeAlgorithms internal slot for BluetoothRemoteGATTServer.
 
-        // Note: Steps 5.1.1 and 5.1.3 are in components/bluetooth/lib.rs in the gatt_server_connect function.
-        // Steps 5.2.4 - 5.2.5  are in response function.
+        // Note: Steps 2, 5.1.1 and 5.1.3 are in components/bluetooth/lib.rs in the gatt_server_connect function.
+        // Steps 5.2.3 - 5.2.5  are in response function.
         self.get_bluetooth_thread().send(
             BluetoothRequest::GATTServerConnect(String::from(self.Device().Id()), sender)).unwrap();
         // Step 5: return promise.
@@ -142,9 +139,7 @@ impl BluetoothRemoteGATTServerMethods for BluetoothRemoteGATTServer {
             return p;
         }
 
-        // TODO: Step 5: Implement representedDevice internal slot for BluetoothDevice.
-
-        // Note: Steps 6 - 7 are implemented in components/bluetooth/lib.rs in get_primary_service function
+        // Note: Steps 5 - 7 are implemented in components/bluetooth/lib.rs in get_primary_service function
         // and in handle_response function.
         let sender = response_async(&p, self);
         self.get_bluetooth_thread().send(
@@ -185,9 +180,7 @@ impl BluetoothRemoteGATTServerMethods for BluetoothRemoteGATTServer {
             return p;
         }
 
-        // TODO: Step 5: Implement representedDevice internal slot for BluetoothDevice.
-
-        // Note: Steps 6 - 7 are implemented in components/bluetooth/lib.rs in get_primary_services function
+        // Note: Steps 5 - 7 are implemented in components/bluetooth/lib.rs in get_primary_services function
         // and in handle_response function.
         let sender = response_async(&p, self);
         self.get_bluetooth_thread().send(

--- a/components/script/dom/bluetoothremotegattservice.rs
+++ b/components/script/dom/bluetoothremotegattservice.rs
@@ -117,9 +117,7 @@ impl BluetoothRemoteGATTServiceMethods for BluetoothRemoteGATTService {
             return p;
         }
 
-        // TODO: Step 5: Implement representedService internal slot for BluetootRemoteGATTService.
-
-        // Note: Steps 6 - 7 are implemented is components/bluetooth/lib.rs in get_characteristic function
+        // Note: Steps 5 - 7 are implemented is components/bluetooth/lib.rs in get_characteristic function
         // and in handle_response function.
         let sender = response_async(&p, self);
         self.get_bluetooth_thread().send(
@@ -160,9 +158,7 @@ impl BluetoothRemoteGATTServiceMethods for BluetoothRemoteGATTService {
             return p;
         }
 
-        // TODO: Step 5: Implement representedService internal slot for BluetootRemoteGATTService.
-
-        // Note: Steps 6 - 7 are implemented is components/bluetooth/lib.rs in get_characteristics function
+        // Note: Steps 5 - 7 are implemented is components/bluetooth/lib.rs in get_characteristics function
         // and in handle_response function.
         let sender = response_async(&p, self);
         self.get_bluetooth_thread().send(
@@ -200,9 +196,7 @@ impl BluetoothRemoteGATTServiceMethods for BluetoothRemoteGATTService {
             return p;
         }
 
-        // TODO: Step 5: Implement representedService internal slot for BluetootRemoteGATTService.
-
-        // Note: Steps 6 - 7 are implemented is components/bluetooth/lib.rs in get_included_service function
+        // Note: Steps 5 - 7 are implemented is components/bluetooth/lib.rs in get_included_service function
         // and in handle_response function.
         let sender = response_async(&p, self);
         self.get_bluetooth_thread().send(
@@ -246,9 +240,7 @@ impl BluetoothRemoteGATTServiceMethods for BluetoothRemoteGATTService {
             return p;
         }
 
-        // TODO: Step 5: Implement representedService internal slot for BluetootRemoteGATTService.
-
-        // Note: Steps 6 - 7 are implemented is components/bluetooth/lib.rs in get_included_services function
+        // Note: Steps 5 - 7 are implemented is components/bluetooth/lib.rs in get_included_services function
         // and in handle_response function.
         let sender = response_async(&p, self);
         self.get_bluetooth_thread().send(


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Update the checks for cached ids in bluetooth/lib.rs, this is identical with the `is representedDevice/Service/Characteristic/Descriptor null` checks in the specification.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

