### PR TITLE
Fix wpt-test timeouts, headless for run wpt-tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5251,12 +5251,12 @@ dependencies = [
 name = "webrender"
 version = "0.60.0"
 source = "git+https://github.com/servo/webrender#95973e6872ff19ab59d1bd26c2ab71260d2d37e7"
-replace = "webrender 0.60.0 (git+https://github.com/imiklos/webrender.git?branch=update_wr60)"
+replace = "webrender 0.60.0 (git+https://github.com/szeged/webrender.git?branch=update_wr60)"
 
 [[package]]
 name = "webrender"
 version = "0.60.0"
-source = "git+https://github.com/imiklos/webrender.git?branch=update_wr60#58d125f08c86570653f58df5fed14d6fe5ea1ced"
+source = "git+https://github.com/szeged/webrender.git?branch=update_wr60#888d69ab1de68857e504a57f09ebfd97e2333239"
 dependencies = [
  "app_units 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5290,9 +5290,9 @@ dependencies = [
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_profiler 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_api 0.60.0 (git+https://github.com/imiklos/webrender.git?branch=update_wr60)",
- "webrender_build 0.0.1 (git+https://github.com/imiklos/webrender.git?branch=update_wr60)",
- "wr_malloc_size_of 0.0.1 (git+https://github.com/imiklos/webrender.git?branch=update_wr60)",
+ "webrender_api 0.60.0 (git+https://github.com/szeged/webrender.git?branch=update_wr60)",
+ "webrender_build 0.0.1 (git+https://github.com/szeged/webrender.git?branch=update_wr60)",
+ "wr_malloc_size_of 0.0.1 (git+https://github.com/szeged/webrender.git?branch=update_wr60)",
  "ws 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -5300,12 +5300,12 @@ dependencies = [
 name = "webrender_api"
 version = "0.60.0"
 source = "git+https://github.com/servo/webrender#95973e6872ff19ab59d1bd26c2ab71260d2d37e7"
-replace = "webrender_api 0.60.0 (git+https://github.com/imiklos/webrender.git?branch=update_wr60)"
+replace = "webrender_api 0.60.0 (git+https://github.com/szeged/webrender.git?branch=update_wr60)"
 
 [[package]]
 name = "webrender_api"
 version = "0.60.0"
-source = "git+https://github.com/imiklos/webrender.git?branch=update_wr60#58d125f08c86570653f58df5fed14d6fe5ea1ced"
+source = "git+https://github.com/szeged/webrender.git?branch=update_wr60#888d69ab1de68857e504a57f09ebfd97e2333239"
 dependencies = [
  "app_units 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5321,13 +5321,13 @@ dependencies = [
  "serde_bytes 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "wr_malloc_size_of 0.0.1 (git+https://github.com/imiklos/webrender.git?branch=update_wr60)",
+ "wr_malloc_size_of 0.0.1 (git+https://github.com/szeged/webrender.git?branch=update_wr60)",
 ]
 
 [[package]]
 name = "webrender_build"
 version = "0.0.1"
-source = "git+https://github.com/imiklos/webrender.git?branch=update_wr60#58d125f08c86570653f58df5fed14d6fe5ea1ced"
+source = "git+https://github.com/szeged/webrender.git?branch=update_wr60#888d69ab1de68857e504a57f09ebfd97e2333239"
 dependencies = [
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -5471,7 +5471,7 @@ dependencies = [
 [[package]]
 name = "wr_malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/imiklos/webrender.git?branch=update_wr60#58d125f08c86570653f58df5fed14d6fe5ea1ced"
+source = "git+https://github.com/szeged/webrender.git?branch=update_wr60#888d69ab1de68857e504a57f09ebfd97e2333239"
 dependencies = [
  "app_units 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.19.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6017,11 +6017,11 @@ dependencies = [
 "checksum wayland-scanner 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3611f231e675e15c2feb7623103e6449edc6f10b0598cafb3e16e590a0561355"
 "checksum wayland-sys 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)" = "2a69d729a1747a5bf40ae05b94c7904b64fbf2381e365c046d872ce4a34aa826"
 "checksum webdriver 0.38.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c6022ea74cc9f0085c01ff24965d935cd40f9592d7a56f13909c65f08ea98149"
-"checksum webrender 0.60.0 (git+https://github.com/imiklos/webrender.git?branch=update_wr60)" = "<none>"
 "checksum webrender 0.60.0 (git+https://github.com/servo/webrender)" = "<none>"
-"checksum webrender_api 0.60.0 (git+https://github.com/imiklos/webrender.git?branch=update_wr60)" = "<none>"
+"checksum webrender 0.60.0 (git+https://github.com/szeged/webrender.git?branch=update_wr60)" = "<none>"
 "checksum webrender_api 0.60.0 (git+https://github.com/servo/webrender)" = "<none>"
-"checksum webrender_build 0.0.1 (git+https://github.com/imiklos/webrender.git?branch=update_wr60)" = "<none>"
+"checksum webrender_api 0.60.0 (git+https://github.com/szeged/webrender.git?branch=update_wr60)" = "<none>"
+"checksum webrender_build 0.0.1 (git+https://github.com/szeged/webrender.git?branch=update_wr60)" = "<none>"
 "checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
@@ -6033,7 +6033,7 @@ dependencies = [
 "checksum winit 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c57c15bd4c0ef18dff33e263e452abe32d00e2e05771cacaa410a14cc1c0776"
 "checksum winit 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d233301129ddd33260b47f76900b50e154b7254546e2edba0e5468a1a5fe4de3"
 "checksum winres 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "aea48d0b4b15ba195fc7250fdfb27736ce3bc327535db1c87a2fcb62371f9ecd"
-"checksum wr_malloc_size_of 0.0.1 (git+https://github.com/imiklos/webrender.git?branch=update_wr60)" = "<none>"
+"checksum wr_malloc_size_of 0.0.1 (git+https://github.com/szeged/webrender.git?branch=update_wr60)" = "<none>"
 "checksum ws 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)" = "329d3e6dd450a9c5c73024e1047f0be7e24121a68484eb0b5368977bee3cf8c3"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum x11 2.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39697e3123f715483d311b5826e254b6f3cfebdd83cf7ef3358f579c3d68e235"

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -151,7 +151,8 @@ pub trait WindowMethods {
     /// run the event loop at the vsync interval.
     fn set_animation_state(&self, _state: AnimationState);
     #[cfg(feature = "winit")]
-    fn get_window(&self) -> &winit::Window;
+    fn get_window(&self) -> Option<&winit::Window>;
+    fn get_inner_size(&self) -> DeviceIntSize;
     /// Register services with a VRServiceManager.
     fn register_vr_services(
         &self,

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -177,9 +177,15 @@ impl webrender_api::RenderNotifier for RenderNotifier {
 
 impl<Window, Back> Servo<Window, Back>
 where
-    Window: WindowMethods + 'static + 'static, Back: gfx_hal::Backend,
+    Window: WindowMethods + 'static + 'static,
+    Back: gfx_hal::Backend,
 {
-    pub fn new(window: Rc<Window>, adapter: gfx_hal::Adapter<Back>, surface: Back::Surface, instance: Box<gfx_hal::Instance<Backend=Back>>) -> Servo<Window, Back> {
+    pub fn new(
+        window: Rc<Window>,
+        adapter: gfx_hal::Adapter<Back>,
+        surface: Option<Back::Surface>,
+        instance: Box<gfx_hal::Instance<Backend=Back>>,
+    ) -> Servo<Window, Back> {
         // Global configuration options, parsed from the command line.
         let opts = opts::get();
 
@@ -226,11 +232,11 @@ where
             debug_flags.set(webrender::DebugFlags::PROFILER_DBG, opts.webrender_stats);
 
             let render_notifier = Box::new(RenderNotifier::new(compositor_proxy.clone()));
-            let size = window.get_window().get_inner_size().unwrap();
+            let size = window.get_inner_size();
             let init = webrender::DeviceInit {
                 instance,
                 adapter,
-                surface: Some(surface),
+                surface,
                 window_size: (size.width as i32, size.height as i32),
                 descriptor_count: None,
                 cache_path: None,

--- a/ports/servo/non_android_main.rs
+++ b/ports/servo/non_android_main.rs
@@ -149,7 +149,7 @@ pub fn main() {
     let instance = back::Instance::create("gfx-rs instance", 1);
     let mut adapters = instance.enumerate_adapters();
     let adapter = adapters.remove(0);
-    let mut surface = instance.create_surface(window.get_window());
+    let surface = window.get_window().map(|w| instance.create_surface(w));
     let mut servo = Servo::new(window.clone(), adapter, surface, Box::new(instance));
     let browser_id = BrowserId::new();
     servo.handle_events(vec![WindowEvent::NewBrowser(target_url, browser_id)]);


### PR DESCRIPTION
This patch fix the newly introduced timeouts on wpt-test.
Upstreaming the changes to run wpt-tests in headless mode.